### PR TITLE
Support json5 and don’t log warnings by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Add to your `gatsby-config.js` (all options are optional; defaults shown here):
           }) => '',
           extensionDataDirectory: // Absolute path to the directory where extensions will be downloaded. Defaults to inside node_modules.
             path.resolve('extensions'),
+          logLevel: 'error'       // Set to 'warn' to debug if something looks wrong
         }
       }]
     }

--- a/lib/vscode/colorThemeData.js
+++ b/lib/vscode/colorThemeData.js
@@ -7,14 +7,14 @@
 
 const path = require('path');
 const fs = require('fs');
-const json = require('comment-json');
+const JSON5 = require('json5');
 const plist = require('plist');
 
 function loadColorTheme(themeLocation, resultRules = [], resultColors = {}) {
 	let name = path.basename(themeLocation).split('.')[0];
 	if (path.extname(themeLocation) === '.json') {
 		const content = fs.readFileSync(themeLocation, 'utf8');
-		let contentValue = json.parse(content);
+		let contentValue = JSON5.parse(content);
 		name = contentValue.name || name;
 		if (contentValue.include) {
 			loadColorTheme(path.join(path.dirname(themeLocation), contentValue.include), resultRules, resultColors);

--- a/package-lock.json
+++ b/package-lock.json
@@ -419,12 +419,6 @@
       "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==",
       "dev": true
     },
-    "@types/comment-json": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@types/comment-json/-/comment-json-1.1.1.tgz",
-      "integrity": "sha512-U70oEqvnkeSSp8BIJwJclERtT13rd9ejK7XkIzMCQQePZe3VW1b7iQggXyW4ZvfGtGeXD0pZw24q5iWNe++HqQ==",
-      "dev": true
-    },
     "@types/decompress": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/@types/decompress/-/decompress-4.2.3.tgz",
@@ -479,6 +473,12 @@
       "version": "20.0.1",
       "resolved": "https://registry.npmjs.org/@types/jest-diff/-/jest-diff-20.0.1.tgz",
       "integrity": "sha512-yALhelO3i0hqZwhjtcr6dYyaLoCHbAMshwtj6cGxTvHZAKXHsYGdff6E8EPw3xLKY0ELUTQ69Q1rQiJENnccMA==",
+      "dev": true
+    },
+    "@types/json5": {
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.30.tgz",
+      "integrity": "sha512-sqm9g7mHlPY/43fcSNrCYfOeX9zkTTK+euO5E6+CVijSMm5tTjkVdwdqRkY3ljjIAf8679vps5jKUoJBCLsMDA==",
       "dev": true
     },
     "@types/lodash": {
@@ -1167,14 +1167,6 @@
       "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
       "dev": true,
       "optional": true
-    },
-    "comment-json": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-1.1.3.tgz",
-      "integrity": "sha1-aYbDMw/uDEyeAMI5jNYa+l2PI54=",
-      "requires": {
-        "json-parser": "^1.0.0"
-      }
     },
     "compare-versions": {
       "version": "3.4.0",
@@ -3107,21 +3099,6 @@
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
     },
-    "json-parser": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/json-parser/-/json-parser-1.1.5.tgz",
-      "integrity": "sha1-5i7FJh0aal/CDoEqMgdAxtkAVnc=",
-      "requires": {
-        "esprima": "^2.7.0"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "2.7.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
-        }
-      }
-    },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -3144,7 +3121,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
       "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
-      "dev": true,
       "requires": {
         "minimist": "^1.2.0"
       }
@@ -3372,8 +3348,7 @@
     "minimist": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-      "dev": true
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mixin-deep": {
       "version": "1.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3224,6 +3224,11 @@
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
     },
+    "loglevel": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.3.tgz",
+      "integrity": "sha512-LoEDv5pgpvWgPF4kNYuIp0qqSJVWak/dML0RY74xlzMZiT9w77teNAwKYKWBTYjlokMirg+o3jBwp+vlLrcfAA=="
+    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -30,10 +30,10 @@
   },
   "homepage": "https://github.com/andrewbranch/gatsby-remark-vscode#readme",
   "devDependencies": {
-    "@types/comment-json": "^1.1.1",
     "@types/decompress": "^4.2.3",
     "@types/glob": "^7.1.1",
     "@types/jest": "^24.0.11",
+    "@types/json5": "0.0.30",
     "@types/lodash.escape": "^4.0.6",
     "@types/lodash.uniq": "^4.5.6",
     "@types/node": "^12.0.0",
@@ -45,8 +45,8 @@
     "typescript": "^3.4.5"
   },
   "dependencies": {
-    "comment-json": "^1.1.3",
     "decompress": "^4.2.0",
+    "json5": "^2.1.0",
     "lodash.escape": "^4.0.1",
     "lodash.uniq": "^4.5.0",
     "oniguruma": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "json5": "^2.1.0",
     "lodash.escape": "^4.0.1",
     "lodash.uniq": "^4.5.0",
+    "loglevel": "^1.6.3",
     "oniguruma": "^7.2.0",
     "plist": "^3.0.1",
     "unist-util-visit": "^1.4.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 // @ts-check
 const fs = require('fs');
 const path = require('path');
+const logger = require('loglevel');
 const visit = require('unist-util-visit');
 const escapeHTML = require('lodash.escape');
 const lineHighlighting = require('./lineHighlighting');
@@ -20,14 +21,14 @@ const styles = fs.readFileSync(path.resolve(__dirname, '../styles.css'), 'utf8')
  * @param {string} rootScopeName
  */
 function warnMissingLanguageFile(missingScopeName, rootScopeName) {
-  console.warn(`No language file was loaded for scope '${missingScopeName}' (requested by '${rootScopeName}').`);
+  logger.warn(`No language file was loaded for scope '${missingScopeName}' (requested by '${rootScopeName}').`);
 }
 
 /**
  * @param {string} lang
  */
 function warnUnknownLanguage(lang) {
-  console.warn(
+  logger.warn(
     `Encountered unknown language '${lang}'. If '${lang}' is an alias for a supported language, ` +
       `use the 'languageAliases' plugin option to map it to the canonical language name.`
   );
@@ -120,6 +121,7 @@ function getStylesFromSettings(settings) {
  * @property {boolean=} injectStyles
  * @property {(colorValue: string, theme: string) => string=} replaceColor
  * @property {string=} extensionDataDirectory
+ * @property {'trace' | 'debug' | 'info' | 'warn' | 'error'=} logLevel
  */
 
 function createPlugin() {
@@ -140,9 +142,11 @@ function createPlugin() {
       getLineClassName = () => '',
       injectStyles = true,
       replaceColor = x => x,
-      extensionDataDirectory = path.resolve(__dirname, '../lib/extensions')
+      extensionDataDirectory = path.resolve(__dirname, '../lib/extensions'),
+      logLevel = 'error'
     } = {}
   ) {
+    logger.setLevel(logLevel);
     /** @type {Record<string, string>} */
     const stylesheets = {};
     const nodes = [];

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,7 +2,7 @@
 const fs = require('fs');
 const util = require('util');
 const path = require('path');
-const json = require('comment-json');
+const JSON5 = require('json5');
 const plist = require('plist');
 const uniq = require('lodash.uniq');
 
@@ -71,7 +71,7 @@ function sanitizeForClassName(str) {
 }
 
 const readFile = util.promisify(fs.readFile);
-const requireJson = /** @param {string} pathName */ pathName => json.parse(fs.readFileSync(pathName, 'utf8'));
+const requireJson = /** @param {string} pathName */ pathName => JSON5.parse(fs.readFileSync(pathName, 'utf8'));
 const requireGrammar = /** @param {string} pathName */ async pathName =>
   path.extname(pathName) === '.json' ? requireJson(pathName) : plist.parse(await readFile(pathName, 'utf8'));
 

--- a/test/gatsby-remark-vscode.test.js
+++ b/test/gatsby-remark-vscode.test.js
@@ -245,3 +245,11 @@ describe('prefers-color-scheme', () => {
     }, markdownAST);
   });
 });
+
+describe('utils', () => {
+  describe('requireJson', () => {
+    it('works with json5', () => {
+      expect(() => realUtils.requireJson(path.resolve(__dirname, 'json5.tmTheme.json'))).not.toThrow();
+    });
+  });
+});

--- a/test/json5.tmTheme.json
+++ b/test/json5.tmTheme.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "vscode://schemas/color-theme",
+	"name": "json5",
+	"tokenColors": [
+		{
+			scope: [
+				"meta.embedded",
+				"source.groovy.embedded",
+			],
+			"settings": {
+				"foreground": "#D4D4D4" // a nice gray
+      }
+    },
+  ],
+}


### PR DESCRIPTION
- Parses themes and languages as json5 (fixes #34)
- Adds `logLevel` option and defaults to `'error'` so you don’t get warnings out of the box!

<img width="625" alt="image" src="https://user-images.githubusercontent.com/3277153/62816897-f8241400-bae2-11e9-9b09-212a6758b924.png">
