### PR TITLE
Allow a space character between tag and options

### DIFF
--- a/src/parseCodeFenceHeader.js
+++ b/src/parseCodeFenceHeader.js
@@ -25,8 +25,15 @@ function parseCodeFenceHeader(input) {
     languageName = parseIdentifier();
   }
   skipTrivia();
-  if (!isEnd() && current() === '{') {
-    options = parseObject();
+  if (!isEnd()) {
+    if (current() === '{') {
+      options = parseObject();
+    } else if (current() === ' ') {
+      pos++;
+      if (current() === '{') {
+        options = parseObject();
+      }
+    }
   }
 
   return { languageName, options };


### PR DESCRIPTION
**NOTE:** I can't seen to be able to install and test this project. I get plenty of errors and I spent some time trying to figure them too, so this is more like a suggestion.

This *should*(I couldn't test) allow a single space character between the language tag and options. I am proposing this because if I don't leave a blank space, my syntax highlighter threats the code block as text, and I have no code highlight on the .md file while I'm editing it. :(

```
```js {1}
const foo = 'bar'
```_ 
```