### PR TITLE
Change `wrapperClassName` to accept both string and function

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,7 @@ Add to your `gatsby-config.js` (all options are optional; defaults shown here):
         // All options are optional. Defaults shown here.
         options: {
           colorTheme: 'Dark+ (default dark)', // Read on for list of included themes. Also accepts object and function forms.
-          wrapperClassName: '',   // Additional class put on 'pre' tag
-          getWrapperClassName: ({ // Function allowing dynamic setting of additional class names on 'pre' tag
-            language,             //   - the language specified for the code fence
-            markdownNode,         //   - the gatsby-transformer-remark GraphQL node
-            codeFenceNode,        //   - the Markdown AST node of the current code fence
-            parsedOptions         //   - any options set on the code fence alongside the language (more on this later)
-          }) => '',
+          wrapperClassName: '',   // Additional class put on 'pre' tag. Also accepts function to set the class dynamically.
           injectStyles: true,     // Injects (minimal) additional CSS for layout and scrolling
           extensions: [],         // Extensions to download from the marketplace to provide more languages and themes
           extensionDataDirectory: // Absolute path to the directory where extensions will be downloaded. Defaults to inside node_modules.
@@ -239,7 +233,7 @@ import 'gatsby-remark-vscode/styles.css';
 
 ### Class names
 
-The generated HTML has ample stable class names, and you can add your own with the `wrapperClassName`, `getWrapperClassName` and `getLineClassName` option. All (non-token-color) included styles have a single class name’s worth of specificity, so it should be easy to override the built-in styles.
+The generated HTML has ample stable class names, and you can add your own with the `wrapperClassName` and `getLineClassName` option. All (non-token-color) included styles have a single class name’s worth of specificity, so it should be easy to override the built-in styles.
 
 ### Variables
 
@@ -341,7 +335,7 @@ Line numbers and ranges aren’t the only things you can pass as options on your
     <Amazing><Stuff /></Amazing>
     ```
 
-`gatsby-remark-vscode` doesn’t inherently understand these things, but it parses the input and allows you to access it in the `colorTheme`, `getWrapperClassName` and `getLineClassName` functions:
+`gatsby-remark-vscode` doesn’t inherently understand these things, but it parses the input and allows you to access it in the `colorTheme`, `wrapperClassName` and `getLineClassName` functions:
 
 ```js
 {
@@ -356,7 +350,8 @@ Line numbers and ranges aren’t the only things you can pass as options on your
     //   nested: { objects: 'yep' }
     // }
     return parsedOptions.theme || 'Dark+ (default dark)';
-  }
+  },
+  wrapperClassName: ({ parsedOptions, language, markdownNode, codeFenceNode }) => '';
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ Add to your `gatsby-config.js` (all options are optional; defaults shown here):
         options: {
           colorTheme: 'Dark+ (default dark)', // Read on for list of included themes. Also accepts object and function forms.
           wrapperClassName: '',   // Additional class put on 'pre' tag
+          getWrapperClassName: ({ // Function allowing dynamic setting of additional class names on 'pre' tag
+            language,             //   - the language specified for the code fence
+            markdownNode,         //   - the gatsby-transformer-remark GraphQL node
+            codeFenceNode,        //   - the Markdown AST node of the current code fence
+            parsedOptions         //   - any options set on the code fence alongside the language (more on this later)
+          }) => '',
           injectStyles: true,     // Injects (minimal) additional CSS for layout and scrolling
           extensions: [],         // Extensions to download from the marketplace to provide more languages and themes
           extensionDataDirectory: // Absolute path to the directory where extensions will be downloaded. Defaults to inside node_modules.
@@ -233,7 +239,7 @@ import 'gatsby-remark-vscode/styles.css';
 
 ### Class names
 
-The generated HTML has ample stable class names, and you can add your own with the `wrapperClassName` and `getLineClassName` option. All (non-token-color) included styles have a single class name’s worth of specificity, so it should be easy to override the built-in styles.
+The generated HTML has ample stable class names, and you can add your own with the `wrapperClassName`, `getWrapperClassName` and `getLineClassName` option. All (non-token-color) included styles have a single class name’s worth of specificity, so it should be easy to override the built-in styles.
 
 ### Variables
 
@@ -335,7 +341,7 @@ Line numbers and ranges aren’t the only things you can pass as options on your
     <Amazing><Stuff /></Amazing>
     ```
 
-`gatsby-remark-vscode` doesn’t inherently understand these things, but it parses the input and allows you to access it in the `colorTheme` and `getLineClassName` functions:
+`gatsby-remark-vscode` doesn’t inherently understand these things, but it parses the input and allows you to access it in the `colorTheme`, `getWrapperClassName` and `getLineClassName` functions:
 
 ```js
 {

--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,7 @@ function createPlugin() {
     {
       colorTheme = 'Default Dark+',
       wrapperClassName = '',
+      getWrapperClassName = () => '',
       languageAliases = {},
       extensions = [],
       getLineClassName = () => '',
@@ -52,6 +53,7 @@ function createPlugin() {
     const lineTransformers = getLineTransformers({
       colorTheme,
       wrapperClassName,
+      getWrapperClassName,
       languageAliases,
       extensions,
       getLineClassName,
@@ -177,7 +179,17 @@ function createPlugin() {
           );
         }
 
-        const className = joinClassNames(wrapperClassName, themeClassNames, 'vscode-highlight');
+        const className = joinClassNames(
+          wrapperClassName,
+          getWrapperClassName({
+            language: languageName,
+            markdownNode,
+            codeFenceNode: node,
+            parsedOptions: options,
+          }),
+          themeClassNames,
+          'vscode-highlight'
+        );
         node.type = 'html';
         node.value = renderHTML(
           pre(

--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,6 @@ function createPlugin() {
     {
       colorTheme = 'Default Dark+',
       wrapperClassName = '',
-      getWrapperClassName = () => '',
       languageAliases = {},
       extensions = [],
       getLineClassName = () => '',
@@ -53,7 +52,6 @@ function createPlugin() {
     const lineTransformers = getLineTransformers({
       colorTheme,
       wrapperClassName,
-      getWrapperClassName,
       languageAliases,
       extensions,
       getLineClassName,
@@ -179,17 +177,17 @@ function createPlugin() {
           );
         }
 
-        const className = joinClassNames(
-          wrapperClassName,
-          getWrapperClassName({
-            language: languageName,
-            markdownNode,
-            codeFenceNode: node,
-            parsedOptions: options,
-          }),
-          themeClassNames,
-          'vscode-highlight'
-        );
+        const wrapperClassNameValue =
+          typeof wrapperClassName === 'function'
+            ? wrapperClassName({
+                language: languageName,
+                markdownNode,
+                codeFenceNode: node,
+                parsedOptions: options
+              })
+            : wrapperClassName;
+
+        const className = joinClassNames(wrapperClassNameValue, themeClassNames, 'vscode-highlight');
         node.type = 'html';
         node.value = renderHTML(
           pre(

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -41,8 +41,7 @@ type ColorThemeOption = string | ColorThemeSettings | ((data: CodeFenceData) => 
 
 interface PluginOptions {
   colorTheme?: ColorThemeOption;
-  wrapperClassName?: string;
-  getWrapperClassName?: (data: CodeFenceData) => string;
+  wrapperClassName?: string | ((data: CodeFenceData) => string);
   languageAliases?: Record<string, string>;
   extensions?: ExtensionDemand[];
   getLineClassName?: (line: LineData) => string;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -42,6 +42,7 @@ type ColorThemeOption = string | ColorThemeSettings | ((data: CodeFenceData) => 
 interface PluginOptions {
   colorTheme?: ColorThemeOption;
   wrapperClassName?: string;
+  getWrapperClassName?: (data: CodeFenceData) => string;
   languageAliases?: Record<string, string>;
   extensions?: ExtensionDemand[];
   getLineClassName?: (line: LineData) => string;

--- a/test/integration/cases/code-fence-meta.expected.html
+++ b/test/integration/cases/code-fence-meta.expected.html
@@ -1,4 +1,5 @@
-<pre class="default-dark vscode-highlight" data-language="js"><code class="vscode-highlight-code"><span class="vscode-highlight-line vscode-highlight-line-highlighted"><span class="mtk3">// should be highlighted</span></span></code></pre>
+<pre class="test-wrapper default-dark vscode-highlight" data-language="js"><code class="vscode-highlight-code"><span class="vscode-highlight-line vscode-highlight-line-highlighted"><span class="mtk3">// should be highlighted</span></span></code></pre>
+<pre class="test-wrapper js-test default-dark vscode-highlight" data-language="js"><code class="vscode-highlight-code"><span class="vscode-highlight-line"><span class="mtk3">// should be highlighted</span></span></code></pre>
 <style class="vscode-highlight-styles">
   :root {
   --vscode-highlight-padding-v: 1rem;

--- a/test/integration/cases/code-fence-meta.js
+++ b/test/integration/cases/code-fence-meta.js
@@ -1,0 +1,9 @@
+module.exports = {
+  wrapperClassName: 'test-wrapper',
+  getWrapperClassName: ({ language, parsedOptions }) => {
+    const { wrapperClass } = parsedOptions;
+    if (wrapperClass) {
+      return `${language}-${wrapperClass}`;
+    }
+  },
+};

--- a/test/integration/cases/code-fence-meta.js
+++ b/test/integration/cases/code-fence-meta.js
@@ -1,9 +1,9 @@
 module.exports = {
-  wrapperClassName: 'test-wrapper',
-  getWrapperClassName: ({ language, parsedOptions }) => {
+  wrapperClassName: ({ language, parsedOptions }) => {
     const { wrapperClass } = parsedOptions;
     if (wrapperClass) {
-      return `${language}-${wrapperClass}`;
+      return `test-wrapper ${language}-${wrapperClass}`;
     }
+    return 'test-wrapper';
   },
 };

--- a/test/integration/cases/code-fence-meta.md
+++ b/test/integration/cases/code-fence-meta.md
@@ -1,3 +1,7 @@
 ```js {1}
 // should be highlighted
 ```
+
+```js {wrapperClass: 'test'}
+// should be highlighted
+```


### PR DESCRIPTION
Change the option `wrapperClassName` to accept both string and function, the function signature is the same as `colorTheme`:

```js
wapperClassName: ({ language, markdownNode, codeFenceNode, parsedOptions}) => '',
```

This option enables users to customize the whole code block style based on the code fence options.

For example, I'm using `::before` pseudo-element to implement line numbers (as suggested by @andrewbranch https://github.com/andrewbranch/gatsby-remark-vscode/issues/28#issuecomment-514688487):

This is how it looks like (the background of the line numbers is actually the left border of the `code` element):
![image](https://user-images.githubusercontent.com/4597409/69167359-cc77e780-0b2f-11ea-9d34-864eb28e4484.png)

However, if I want to disable line number on some certain code blocks, I can use `getLineClassName` to hide the pseudo-element.

```js
getLineClassName: ({ codeFenceOptions }) => {
  if (codeFenceOptions.ln === false) {
    return 'no-ln';
  }
}
```
```css
.vscode-highlight-line.no-ln::before {
  display: none;
}
```

But I couldn't find a way to unset the left border of the `code` block, because there's no such parent or child level forward-looking css selectors.

![image](https://user-images.githubusercontent.com/4597409/69167960-c20a1d80-0b30-11ea-97ca-b939afb91207.png)

If this option is there, I can just apply another class on the `pre > code` block to unset to the left border.

And other cases can be:

- Line number toggle
- More customizable dynamic styles rather than just `colorTheme`: https://github.com/andrewbranch/gatsby-remark-vscode/issues/43, https://github.com/andrewbranch/gatsby-remark-vscode/issues/39
- Widget toggle, such as language label
- Overflow/line wrap control

What I have done for this PR:

- [x] The function itself
- [x] Integration test case
- [x] Type definition
- [x] README
- [ ] Version bump