### PR TITLE
Fix issue when using code fences in nodes not sourced from filesystem

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -90,7 +90,7 @@ function createPlugin() {
       const possibleThemes = await getPossibleThemes(
         theme,
         await cache.get('themes'),
-        path.dirname(markdownNode.fileAbsolutePath),
+        markdownNode.fileAbsolutePath ? path.dirname(markdownNode.fileAbsolutePath) : null,
         markdownNode,
         node,
         languageName,


### PR DESCRIPTION
I'm creating `text/markdown` nodes in my gatsby site manually from data from an API. The markdown files are not on the filesystem. I kept receiving the following error, but only when it would parse markdown with code fences while using this plugin:

```
"gatsby-plugin-mdx" threw an error while running the onCreateNode lifecycle:
The "path" argument must be of type string. Received undefined
```

I traced it down to the `getPossibleThemes` call in this plugin. The node doesn't get a `fileAbsolutePath` on it unless it is sourced from a file node, which mine aren't.

Checking for the existence of the path before calling `path.dirname` fixes the issue for me.