### PR TITLE
Use CSS variable fallbacks instead of default values on :root

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,26 +274,44 @@ The generated HTML has ample stable class names, and you can add your own with t
 
 ### Variables
 
-The styles also include a few CSS variables you can override. The defaults are:
+The styles also include a few CSS variables you can define to override defaults. The included CSS is written as:
 
 ```css
 .grvsc-container {
-  --grvsc-padding-v: 1rem;
-  --grvsc-padding-h: 1.5rem;
-  --grvsc-padding-top: var(--grvsc-padding-v);
-  --grvsc-padding-right: var(--grvsc-padding-h);
-  --grvsc-padding-bottom: var(--grvsc-padding-v);
-  --grvsc-padding-left: var(--grvsc-padding-h);
-  --grvsc-border-radius: 8px;
+  padding-top: var(--grvsc-padding-top, var(--grvsc-padding-v, 1rem));
+  padding-bottom: var(--grvsc-padding-bottom, var(--grvsc-padding-v, 1rem));
+  border-radius: var(--grvsc-border-radius, 8px);
+}
 
-  /* Line highlighting: see next section */
-  --grvsc-line-highlighted-background-color: transparent;
-  --grvsc-line-highlighted-border-width: 4px;
-  --grvsc-line-highlighted-border-color: transparent;
+.grvsc-line {
+  padding-left: var(--grvsc-padding-left, var(--grvsc-padding-h, 1.5rem));
+  padding-right: var(--grvsc-padding-right, var(--grvsc-padding-h, 1.5rem));
+}
+
+/* See “Line Highlighting” section for details */
+.grvsc-line-highlighted {
+  background-color: var(--grvsc-line-highlighted-background-color, transparent);
+  box-shadow: inset var(--grvsc-line-highlighted-border-width, 4px) 0 0 0 var(--grvsc-line-highlighted-border-color, transparent);
 }
 ```
 
-The default values are set on `:root`, so you can set them on `.grvsc-container`, `pre`, your own `wrapperClassName`, the class name matching the theme, or generally any selector more specific than `:root`.
+The padding values are written with cascading fallbacks. As an example, let’s consider the top and bottom padding of `.grvsc-container`. Each is set to its own CSS variable, `--grvsc-padding-top` and `--grvsc-padding-bottom`, respectively. Neither of these is defined by default, so it uses the value of its fallback, which is another CSS variable, `--grvsc-padding-v`, with another fallback, `1rem`. Since `--grvsc-padding-v` is also not defined by default, both padding properties will evaluate to the final fallback, `1rem`.
+
+So, if you want to adjust the vertical padding, you could add the following to your own CSS:
+
+```css
+:root {
+  --grvsc-padding-v: 20px; /* Adjust padding-top and padding-bottom */
+}
+```
+
+If you want to adjust the padding-top or padding-bottom independently, you can use those variables:
+
+```css
+:root {
+  --grvsc-padding-top: 24px; /* Adjust padding-top by itself */
+}
+```
 
 ### Tweaking or replacing theme colors
 
@@ -348,10 +366,10 @@ const zero = [0, 1, 2, 3, 4, 5]
 You need to pick your own background color, and optionally a left border width and color, for the highlighted lines. This can be done by setting CSS variables:
 
 ```css
-.grvsc-container {
+:root {
   --grvsc-line-highlighted-background-color: rgba(255, 255, 255, 0.2); /* default: transparent */
   --grvsc-line-highlighted-border-color: rgba(255, 255, 255, 0.5); /* default: transparent */
-  --grvsc-line-highlighted-border-width: 2px; /* default: 2px */
+  --grvsc-line-highlighted-border-width: 2px; /* default: 4px */
 }
 ```
 

--- a/styles.css
+++ b/styles.css
@@ -1,26 +1,12 @@
-:root {
-  --grvsc-padding-v: 1rem;
-  --grvsc-padding-h: 1.5rem;
-  --grvsc-padding-top: var(--grvsc-padding-v);
-  --grvsc-padding-right: var(--grvsc-padding-h);
-  --grvsc-padding-bottom: var(--grvsc-padding-v);
-  --grvsc-padding-left: var(--grvsc-padding-h);
-  --grvsc-border-radius: 8px;
-
-  --grvsc-line-highlighted-background-color: transparent;
-  --grvsc-line-highlighted-border-width: 4px;
-  --grvsc-line-highlighted-border-color: transparent;
-}
-
 .grvsc-container {
   overflow: auto;
   -webkit-overflow-scrolling: touch;
   padding-top: 1rem;
-  padding-top: var(--grvsc-padding-top);
+  padding-top: var(--grvsc-padding-top, var(--grvsc-padding-v, 1rem));
   padding-bottom: 1rem;
-  padding-bottom: var(--grvsc-padding-bottom);
+  padding-bottom: var(--grvsc-padding-bottom, var(--grvsc-padding-v, 1rem));
   border-radius: 8px;
-  border-radius: var(--grvsc-border-radius);
+  border-radius: var(--grvsc-border-radius, 8px);
   font-feature-settings: normal;
 }
 
@@ -34,12 +20,12 @@
   box-sizing: border-box;
   width: 100%;
   padding-left: 1.5rem;
-  padding-left: var(--grvsc-padding-left);
+  padding-left: var(--grvsc-padding-left, var(--grvsc-padding-h, 1.5rem));
   padding-right: 1.5rem;
-  padding-right: var(--grvsc-padding-right);
+  padding-right: var(--grvsc-padding-right, var(--grvsc-padding-h, 1.5rem));
 }
 
 .grvsc-line-highlighted {
-  background-color: var(--grvsc-line-highlighted-background-color);
-  box-shadow: inset var(--grvsc-line-highlighted-border-width) 0 0 0 var(--grvsc-line-highlighted-border-color);
+  background-color: var(--grvsc-line-highlighted-background-color, transparent);
+  box-shadow: inset var(--grvsc-line-highlighted-border-width, 4px) 0 0 0 var(--grvsc-line-highlighted-border-color, transparent);
 }

--- a/test/integration/baselines/bug-37.html
+++ b/test/integration/baselines/bug-37.html
@@ -10,29 +10,15 @@
 <span class="grvsc-line"><span class="mtk1">   </span><span class="mtk17">&#x3C;/</span><span class="mtk4">rdf:RDF</span><span class="mtk17">></span></span>
 <span class="grvsc-line"><span class="mtk17">&#x3C;/</span><span class="mtk4">x:xmpmeta</span><span class="mtk17">></span></span></code></pre>
 <style class="grvsc-styles">
-  :root {
-    --grvsc-padding-v: 1rem;
-    --grvsc-padding-h: 1.5rem;
-    --grvsc-padding-top: var(--grvsc-padding-v);
-    --grvsc-padding-right: var(--grvsc-padding-h);
-    --grvsc-padding-bottom: var(--grvsc-padding-v);
-    --grvsc-padding-left: var(--grvsc-padding-h);
-    --grvsc-border-radius: 8px;
-  
-    --grvsc-line-highlighted-background-color: transparent;
-    --grvsc-line-highlighted-border-width: 4px;
-    --grvsc-line-highlighted-border-color: transparent;
-  }
-  
   .grvsc-container {
     overflow: auto;
     -webkit-overflow-scrolling: touch;
     padding-top: 1rem;
-    padding-top: var(--grvsc-padding-top);
+    padding-top: var(--grvsc-padding-top, var(--grvsc-padding-v, 1rem));
     padding-bottom: 1rem;
-    padding-bottom: var(--grvsc-padding-bottom);
+    padding-bottom: var(--grvsc-padding-bottom, var(--grvsc-padding-v, 1rem));
     border-radius: 8px;
-    border-radius: var(--grvsc-border-radius);
+    border-radius: var(--grvsc-border-radius, 8px);
     font-feature-settings: normal;
   }
   
@@ -46,14 +32,14 @@
     box-sizing: border-box;
     width: 100%;
     padding-left: 1.5rem;
-    padding-left: var(--grvsc-padding-left);
+    padding-left: var(--grvsc-padding-left, var(--grvsc-padding-h, 1.5rem));
     padding-right: 1.5rem;
-    padding-right: var(--grvsc-padding-right);
+    padding-right: var(--grvsc-padding-right, var(--grvsc-padding-h, 1.5rem));
   }
   
   .grvsc-line-highlighted {
-    background-color: var(--grvsc-line-highlighted-background-color);
-    box-shadow: inset var(--grvsc-line-highlighted-border-width) 0 0 0 var(--grvsc-line-highlighted-border-color);
+    background-color: var(--grvsc-line-highlighted-background-color, transparent);
+    box-shadow: inset var(--grvsc-line-highlighted-border-width, 4px) 0 0 0 var(--grvsc-line-highlighted-border-color, transparent);
   }
   
   .default-dark {

--- a/test/integration/baselines/code-fence-meta.html
+++ b/test/integration/baselines/code-fence-meta.html
@@ -1,29 +1,15 @@
 <pre class="grvsc-container test-wrapper default-dark" data-language="js" data-index="0"><code class="grvsc-code"><span class="grvsc-line grvsc-line-highlighted"><span class="mtk3">// should be highlighted</span></span></code></pre>
 <pre class="grvsc-container test-wrapper js-test default-dark" data-language="js" data-index="1"><code class="grvsc-code"><span class="grvsc-line"><span class="mtk3">// should not be highlighted</span></span></code></pre>
 <style class="grvsc-styles">
-  :root {
-    --grvsc-padding-v: 1rem;
-    --grvsc-padding-h: 1.5rem;
-    --grvsc-padding-top: var(--grvsc-padding-v);
-    --grvsc-padding-right: var(--grvsc-padding-h);
-    --grvsc-padding-bottom: var(--grvsc-padding-v);
-    --grvsc-padding-left: var(--grvsc-padding-h);
-    --grvsc-border-radius: 8px;
-  
-    --grvsc-line-highlighted-background-color: transparent;
-    --grvsc-line-highlighted-border-width: 4px;
-    --grvsc-line-highlighted-border-color: transparent;
-  }
-  
   .grvsc-container {
     overflow: auto;
     -webkit-overflow-scrolling: touch;
     padding-top: 1rem;
-    padding-top: var(--grvsc-padding-top);
+    padding-top: var(--grvsc-padding-top, var(--grvsc-padding-v, 1rem));
     padding-bottom: 1rem;
-    padding-bottom: var(--grvsc-padding-bottom);
+    padding-bottom: var(--grvsc-padding-bottom, var(--grvsc-padding-v, 1rem));
     border-radius: 8px;
-    border-radius: var(--grvsc-border-radius);
+    border-radius: var(--grvsc-border-radius, 8px);
     font-feature-settings: normal;
   }
   
@@ -37,14 +23,14 @@
     box-sizing: border-box;
     width: 100%;
     padding-left: 1.5rem;
-    padding-left: var(--grvsc-padding-left);
+    padding-left: var(--grvsc-padding-left, var(--grvsc-padding-h, 1.5rem));
     padding-right: 1.5rem;
-    padding-right: var(--grvsc-padding-right);
+    padding-right: var(--grvsc-padding-right, var(--grvsc-padding-h, 1.5rem));
   }
   
   .grvsc-line-highlighted {
-    background-color: var(--grvsc-line-highlighted-background-color);
-    box-shadow: inset var(--grvsc-line-highlighted-border-width) 0 0 0 var(--grvsc-line-highlighted-border-color);
+    background-color: var(--grvsc-line-highlighted-background-color, transparent);
+    box-shadow: inset var(--grvsc-line-highlighted-border-width, 4px) 0 0 0 var(--grvsc-line-highlighted-border-color, transparent);
   }
   
   .default-dark {

--- a/test/integration/baselines/github-zip.html
+++ b/test/integration/baselines/github-zip.html
@@ -7,29 +7,15 @@
 <span class="grvsc-line"><span class="mtk1">  </span><span class="mtk13">await</span><span class="mtk1"> </span><span class="mtk20">cache</span><span class="mtk6">.</span><span class="mtk9">set</span><span class="mtk1">(</span><span class="mtk20">key</span><span class="mtk6">,</span><span class="mtk1"> </span><span class="mtk6">{</span><span class="mtk1"> </span><span class="mtk6">...</span><span class="mtk1">(</span><span class="mtk13">await</span><span class="mtk1"> </span><span class="mtk20">cache</span><span class="mtk6">.</span><span class="mtk9">get</span><span class="mtk1">(</span><span class="mtk20">key</span><span class="mtk1">))</span><span class="mtk6">,</span><span class="mtk1"> </span><span class="mtk6">...</span><span class="mtk20">value</span><span class="mtk1"> </span><span class="mtk6">}</span><span class="mtk1">)</span><span class="mtk6">;</span></span>
 <span class="grvsc-line"><span class="mtk6">}</span></span></code></pre>
 <style class="grvsc-styles">
-  :root {
-    --grvsc-padding-v: 1rem;
-    --grvsc-padding-h: 1.5rem;
-    --grvsc-padding-top: var(--grvsc-padding-v);
-    --grvsc-padding-right: var(--grvsc-padding-h);
-    --grvsc-padding-bottom: var(--grvsc-padding-v);
-    --grvsc-padding-left: var(--grvsc-padding-h);
-    --grvsc-border-radius: 8px;
-  
-    --grvsc-line-highlighted-background-color: transparent;
-    --grvsc-line-highlighted-border-width: 4px;
-    --grvsc-line-highlighted-border-color: transparent;
-  }
-  
   .grvsc-container {
     overflow: auto;
     -webkit-overflow-scrolling: touch;
     padding-top: 1rem;
-    padding-top: var(--grvsc-padding-top);
+    padding-top: var(--grvsc-padding-top, var(--grvsc-padding-v, 1rem));
     padding-bottom: 1rem;
-    padding-bottom: var(--grvsc-padding-bottom);
+    padding-bottom: var(--grvsc-padding-bottom, var(--grvsc-padding-v, 1rem));
     border-radius: 8px;
-    border-radius: var(--grvsc-border-radius);
+    border-radius: var(--grvsc-border-radius, 8px);
     font-feature-settings: normal;
   }
   
@@ -43,14 +29,14 @@
     box-sizing: border-box;
     width: 100%;
     padding-left: 1.5rem;
-    padding-left: var(--grvsc-padding-left);
+    padding-left: var(--grvsc-padding-left, var(--grvsc-padding-h, 1.5rem));
     padding-right: 1.5rem;
-    padding-right: var(--grvsc-padding-right);
+    padding-right: var(--grvsc-padding-right, var(--grvsc-padding-h, 1.5rem));
   }
   
   .grvsc-line-highlighted {
-    background-color: var(--grvsc-line-highlighted-background-color);
-    box-shadow: inset var(--grvsc-line-highlighted-border-width) 0 0 0 var(--grvsc-line-highlighted-border-color);
+    background-color: var(--grvsc-line-highlighted-background-color, transparent);
+    box-shadow: inset var(--grvsc-line-highlighted-border-width, 4px) 0 0 0 var(--grvsc-line-highlighted-border-color, transparent);
   }
   
   .oceanic-plus {

--- a/test/integration/baselines/highlight-directive-comments.html
+++ b/test/integration/baselines/highlight-directive-comments.html
@@ -15,29 +15,15 @@
 <span class="grvsc-line grvsc-line-highlighted"><span class="mtk1">  </span><span class="mtk15">case</span><span class="mtk1"> </span><span class="mtk11">two</span><span class="mtk1">(</span><span class="mtk12">_</span><span class="mtk1"> name: </span><span class="mtk10">String</span><span class="mtk1">)</span></span>
 <span class="grvsc-line"><span class="mtk1">}</span></span></code></pre>
 <style class="grvsc-styles">
-  :root {
-    --grvsc-padding-v: 1rem;
-    --grvsc-padding-h: 1.5rem;
-    --grvsc-padding-top: var(--grvsc-padding-v);
-    --grvsc-padding-right: var(--grvsc-padding-h);
-    --grvsc-padding-bottom: var(--grvsc-padding-v);
-    --grvsc-padding-left: var(--grvsc-padding-h);
-    --grvsc-border-radius: 8px;
-  
-    --grvsc-line-highlighted-background-color: transparent;
-    --grvsc-line-highlighted-border-width: 4px;
-    --grvsc-line-highlighted-border-color: transparent;
-  }
-  
   .grvsc-container {
     overflow: auto;
     -webkit-overflow-scrolling: touch;
     padding-top: 1rem;
-    padding-top: var(--grvsc-padding-top);
+    padding-top: var(--grvsc-padding-top, var(--grvsc-padding-v, 1rem));
     padding-bottom: 1rem;
-    padding-bottom: var(--grvsc-padding-bottom);
+    padding-bottom: var(--grvsc-padding-bottom, var(--grvsc-padding-v, 1rem));
     border-radius: 8px;
-    border-radius: var(--grvsc-border-radius);
+    border-radius: var(--grvsc-border-radius, 8px);
     font-feature-settings: normal;
   }
   
@@ -51,14 +37,14 @@
     box-sizing: border-box;
     width: 100%;
     padding-left: 1.5rem;
-    padding-left: var(--grvsc-padding-left);
+    padding-left: var(--grvsc-padding-left, var(--grvsc-padding-h, 1.5rem));
     padding-right: 1.5rem;
-    padding-right: var(--grvsc-padding-right);
+    padding-right: var(--grvsc-padding-right, var(--grvsc-padding-h, 1.5rem));
   }
   
   .grvsc-line-highlighted {
-    background-color: var(--grvsc-line-highlighted-background-color);
-    box-shadow: inset var(--grvsc-line-highlighted-border-width) 0 0 0 var(--grvsc-line-highlighted-border-color);
+    background-color: var(--grvsc-line-highlighted-background-color, transparent);
+    box-shadow: inset var(--grvsc-line-highlighted-border-width, 4px) 0 0 0 var(--grvsc-line-highlighted-border-color, transparent);
   }
   
   .default-dark {

--- a/test/integration/baselines/npm-extension.html
+++ b/test/integration/baselines/npm-extension.html
@@ -7,29 +7,15 @@
 <span class="grvsc-line"><span class="mtk1">  </span><span class="mtk9">await</span><span class="mtk1"> </span><span class="mtk3">cache</span><span class="mtk1">.</span><span class="mtk6">set</span><span class="mtk1">(</span><span class="mtk3">key</span><span class="mtk1">, { </span><span class="mtk9">...</span><span class="mtk1">(</span><span class="mtk9">await</span><span class="mtk1"> </span><span class="mtk3">cache</span><span class="mtk1">.</span><span class="mtk6">get</span><span class="mtk1">(</span><span class="mtk3">key</span><span class="mtk1">)), </span><span class="mtk9">...</span><span class="mtk3">value</span><span class="mtk1"> });</span></span>
 <span class="grvsc-line"><span class="mtk1">}</span></span></code></pre>
 <style class="grvsc-styles">
-  :root {
-    --grvsc-padding-v: 1rem;
-    --grvsc-padding-h: 1.5rem;
-    --grvsc-padding-top: var(--grvsc-padding-v);
-    --grvsc-padding-right: var(--grvsc-padding-h);
-    --grvsc-padding-bottom: var(--grvsc-padding-v);
-    --grvsc-padding-left: var(--grvsc-padding-h);
-    --grvsc-border-radius: 8px;
-  
-    --grvsc-line-highlighted-background-color: transparent;
-    --grvsc-line-highlighted-border-width: 4px;
-    --grvsc-line-highlighted-border-color: transparent;
-  }
-  
   .grvsc-container {
     overflow: auto;
     -webkit-overflow-scrolling: touch;
     padding-top: 1rem;
-    padding-top: var(--grvsc-padding-top);
+    padding-top: var(--grvsc-padding-top, var(--grvsc-padding-v, 1rem));
     padding-bottom: 1rem;
-    padding-bottom: var(--grvsc-padding-bottom);
+    padding-bottom: var(--grvsc-padding-bottom, var(--grvsc-padding-v, 1rem));
     border-radius: 8px;
-    border-radius: var(--grvsc-border-radius);
+    border-radius: var(--grvsc-border-radius, 8px);
     font-feature-settings: normal;
   }
   
@@ -43,14 +29,14 @@
     box-sizing: border-box;
     width: 100%;
     padding-left: 1.5rem;
-    padding-left: var(--grvsc-padding-left);
+    padding-left: var(--grvsc-padding-left, var(--grvsc-padding-h, 1.5rem));
     padding-right: 1.5rem;
-    padding-right: var(--grvsc-padding-right);
+    padding-right: var(--grvsc-padding-right, var(--grvsc-padding-h, 1.5rem));
   }
   
   .grvsc-line-highlighted {
-    background-color: var(--grvsc-line-highlighted-background-color);
-    box-shadow: inset var(--grvsc-line-highlighted-border-width) 0 0 0 var(--grvsc-line-highlighted-border-color);
+    background-color: var(--grvsc-line-highlighted-background-color, transparent);
+    box-shadow: inset var(--grvsc-line-highlighted-border-width, 4px) 0 0 0 var(--grvsc-line-highlighted-border-color, transparent);
   }
   
   .synthwave-vscode { background-color: #262335; }

--- a/test/integration/baselines/parent-selector.html
+++ b/test/integration/baselines/parent-selector.html
@@ -1,28 +1,14 @@
 <pre class="grvsc-container default-light grvsc-ps-tYvMB2" data-language="js" data-index="0"><code class="grvsc-code"><span class="grvsc-line"><span class="grvsc-t7UkM5-9 grvsc-tYvMB2-10">console</span><span class="grvsc-t7UkM5-1 grvsc-tYvMB2-1">.</span><span class="grvsc-t7UkM5-10 grvsc-tYvMB2-11">log</span><span class="grvsc-t7UkM5-1 grvsc-tYvMB2-1">(</span><span class="grvsc-t7UkM5-17 grvsc-tYvMB2-8">"Hello, world!"</span><span class="grvsc-t7UkM5-1 grvsc-tYvMB2-1">);</span></span></code></pre>
 <style class="grvsc-styles">
-  :root {
-    --grvsc-padding-v: 1rem;
-    --grvsc-padding-h: 1.5rem;
-    --grvsc-padding-top: var(--grvsc-padding-v);
-    --grvsc-padding-right: var(--grvsc-padding-h);
-    --grvsc-padding-bottom: var(--grvsc-padding-v);
-    --grvsc-padding-left: var(--grvsc-padding-h);
-    --grvsc-border-radius: 8px;
-  
-    --grvsc-line-highlighted-background-color: transparent;
-    --grvsc-line-highlighted-border-width: 4px;
-    --grvsc-line-highlighted-border-color: transparent;
-  }
-  
   .grvsc-container {
     overflow: auto;
     -webkit-overflow-scrolling: touch;
     padding-top: 1rem;
-    padding-top: var(--grvsc-padding-top);
+    padding-top: var(--grvsc-padding-top, var(--grvsc-padding-v, 1rem));
     padding-bottom: 1rem;
-    padding-bottom: var(--grvsc-padding-bottom);
+    padding-bottom: var(--grvsc-padding-bottom, var(--grvsc-padding-v, 1rem));
     border-radius: 8px;
-    border-radius: var(--grvsc-border-radius);
+    border-radius: var(--grvsc-border-radius, 8px);
     font-feature-settings: normal;
   }
   
@@ -36,14 +22,14 @@
     box-sizing: border-box;
     width: 100%;
     padding-left: 1.5rem;
-    padding-left: var(--grvsc-padding-left);
+    padding-left: var(--grvsc-padding-left, var(--grvsc-padding-h, 1.5rem));
     padding-right: 1.5rem;
-    padding-right: var(--grvsc-padding-right);
+    padding-right: var(--grvsc-padding-right, var(--grvsc-padding-h, 1.5rem));
   }
   
   .grvsc-line-highlighted {
-    background-color: var(--grvsc-line-highlighted-background-color);
-    box-shadow: inset var(--grvsc-line-highlighted-border-width) 0 0 0 var(--grvsc-line-highlighted-border-color);
+    background-color: var(--grvsc-line-highlighted-background-color, transparent);
+    box-shadow: inset var(--grvsc-line-highlighted-border-width, 4px) 0 0 0 var(--grvsc-line-highlighted-border-color, transparent);
   }
   
   .default-light {

--- a/test/integration/baselines/vsix.html
+++ b/test/integration/baselines/vsix.html
@@ -7,29 +7,15 @@
 <span class="grvsc-line"><span class="mtk1">  </span><span class="mtk10">await</span><span class="mtk1"> </span><span class="mtk4">cache</span><span class="mtk1">.</span><span class="mtk3">set</span><span class="mtk1">(</span><span class="mtk4">key</span><span class="mtk1">, { ...(</span><span class="mtk10">await</span><span class="mtk1"> </span><span class="mtk4">cache</span><span class="mtk1">.</span><span class="mtk3">get</span><span class="mtk1">(</span><span class="mtk4">key</span><span class="mtk1">)), ...</span><span class="mtk4">value</span><span class="mtk1"> });</span></span>
 <span class="grvsc-line"><span class="mtk1">}</span></span></code></pre>
 <style class="grvsc-styles">
-  :root {
-    --grvsc-padding-v: 1rem;
-    --grvsc-padding-h: 1.5rem;
-    --grvsc-padding-top: var(--grvsc-padding-v);
-    --grvsc-padding-right: var(--grvsc-padding-h);
-    --grvsc-padding-bottom: var(--grvsc-padding-v);
-    --grvsc-padding-left: var(--grvsc-padding-h);
-    --grvsc-border-radius: 8px;
-  
-    --grvsc-line-highlighted-background-color: transparent;
-    --grvsc-line-highlighted-border-width: 4px;
-    --grvsc-line-highlighted-border-color: transparent;
-  }
-  
   .grvsc-container {
     overflow: auto;
     -webkit-overflow-scrolling: touch;
     padding-top: 1rem;
-    padding-top: var(--grvsc-padding-top);
+    padding-top: var(--grvsc-padding-top, var(--grvsc-padding-v, 1rem));
     padding-bottom: 1rem;
-    padding-bottom: var(--grvsc-padding-bottom);
+    padding-bottom: var(--grvsc-padding-bottom, var(--grvsc-padding-v, 1rem));
     border-radius: 8px;
-    border-radius: var(--grvsc-border-radius);
+    border-radius: var(--grvsc-border-radius, 8px);
     font-feature-settings: normal;
   }
   
@@ -43,14 +29,14 @@
     box-sizing: border-box;
     width: 100%;
     padding-left: 1.5rem;
-    padding-left: var(--grvsc-padding-left);
+    padding-left: var(--grvsc-padding-left, var(--grvsc-padding-h, 1.5rem));
     padding-right: 1.5rem;
-    padding-right: var(--grvsc-padding-right);
+    padding-right: var(--grvsc-padding-right, var(--grvsc-padding-h, 1.5rem));
   }
   
   .grvsc-line-highlighted {
-    background-color: var(--grvsc-line-highlighted-background-color);
-    box-shadow: inset var(--grvsc-line-highlighted-border-width) 0 0 0 var(--grvsc-line-highlighted-border-color);
+    background-color: var(--grvsc-line-highlighted-background-color, transparent);
+    box-shadow: inset var(--grvsc-line-highlighted-border-width, 4px) 0 0 0 var(--grvsc-line-highlighted-border-color, transparent);
   }
   
   .one-dark-pro {


### PR DESCRIPTION
Scoping of CSS variables made it so `--grvsc-padding-h` and `--grvsc-padding-v` didn’t work unless defined on `:root`, which is problematic for `injectStyles: true` since the injected styles would likely be defined _after_ the user styles, overriding them. By using fallback values instead of defining defaults on `:root`, we ensure that user-defined variables _always_ win over the defaults (as long as they’re defined on a selector that `.grvsc-container` can inherit from).

Fixes #82 