### PR TITLE
Add diff highlighting line transformer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Prerequisites: development is supported on the current [Node LTS](https://nodejs
 1. Fork and clone the repo.
 2. Run `npm install`
 
-Running `npm install` should automatically initialize or update the [vscode](./vscode) submodule, generate `src/graphql/schema.d.ts`, and populate [`lib/grammars`](lib/grammars) and [`lib/themes`](lib/themes). If any of these things are missing, you’ll errors when you try to run things later. You can rerun these steps with `npm run build`.
+Running `npm install` should automatically initialize or update the [vscode](./vscode) submodule, generate `src/graphql/schema.d.ts`, and populate [`lib/grammars`](lib/grammars) and [`lib/themes`](lib/themes). If any of these things are missing, you’ll get errors when you try to run things later. You can rerun these steps with `npm run build`.
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ The following languages and themes can be used without [installing third-party e
 
 </details>
 
-Language names are resolve case-insensitively by any aliases and file extensions listed in the grammar’s metadata. For example, a code fence with C++ code in it can use [any of these language codes](https://github.com/Microsoft/vscode/blob/da3c97f3668393ebfcb9f8208d7616018d6d1859/extensions/cpp/package.json#L20-L21). You could also check the [built-in grammar manifest](https://unpkg.com/gatsby-remark-vscode@1.0.3/lib/grammars/manifest.json) for an exact list of mappings.
+Language names are resolved case-insensitively by any aliases and file extensions listed in the grammar’s metadata. For example, a code fence with C++ code in it can use [any of these language codes](https://github.com/Microsoft/vscode/blob/da3c97f3668393ebfcb9f8208d7616018d6d1859/extensions/cpp/package.json#L20-L21). You could also check the [built-in grammar manifest](https://unpkg.com/gatsby-remark-vscode@1.0.3/lib/grammars/manifest.json) for an exact list of mappings.
 
 ### Themes
 

--- a/src/transformers/diffLineTransformer.js
+++ b/src/transformers/diffLineTransformer.js
@@ -3,13 +3,14 @@ const { highlightDiffLine } = require('./transformerUtils');
 
 function createDiffLineTransformer() {
   // How do I get the parsed code fence options here?
-  /** @type {LineTransformer<any>} */
+  /** @type {LineTransformer<undefined>} */
   const diffLineTransformer = ({ line, meta: { diff } }) => {
     if (diff && line.text.startsWith('+')) {
       const text = line.text.replace(/^\+ ?/, '');
       return {
         line: highlightDiffLine({ ...line, text }, 'add'),
         data: { diff: 'ADD' },
+        state: undefined,
         setContainerClassName: 'grvsc-has-line-highlighting',
         gutterCells: [
           {
@@ -24,6 +25,7 @@ function createDiffLineTransformer() {
       return {
         line: highlightDiffLine({ ...line, text }, 'del'),
         data: { diff: 'DEL' },
+        state: undefined,
         setContainerClassName: 'grvsc-has-line-highlighting',
         gutterCells: [
           {
@@ -33,7 +35,7 @@ function createDiffLineTransformer() {
         ]
       };
     }
-    return { line };
+    return { line, state: undefined };
   };
 
   diffLineTransformer.displayName = 'diff';

--- a/src/transformers/diffLineTransformer.js
+++ b/src/transformers/diffLineTransformer.js
@@ -2,11 +2,10 @@
 const { highlightDiffLine } = require('./transformerUtils');
 
 function createDiffLineTransformer() {
-  // How do I get the parsed code fence options here?
   /** @type {LineTransformer<undefined>} */
   const diffLineTransformer = ({ line, meta: { diff } }) => {
     if (diff && line.text.startsWith('+')) {
-      const text = line.text.replace(/^\+ ?/, '');
+      const text = line.text.slice(line.text[1] === ' ' ? 2 : 1);
       return {
         line: highlightDiffLine({ ...line, text }, 'add'),
         data: { diff: 'ADD' },
@@ -21,7 +20,7 @@ function createDiffLineTransformer() {
       };
     }
     if (diff && line.text.startsWith('-')) {
-      const text = line.text.replace(/^- ?/, '');
+      const text = line.text.slice(line.text[1] === ' ' ? 2 : 1);
       return {
         line: highlightDiffLine({ ...line, text }, 'del'),
         data: { diff: 'DEL' },

--- a/src/transformers/diffLineTransformer.js
+++ b/src/transformers/diffLineTransformer.js
@@ -1,0 +1,33 @@
+// @ts-check
+const { highlightDiffLine } = require('./transformerUtils');
+
+function createDiffLineTransformer() {
+  // How do I get the parsed code fence options here?
+  /** @type {LineTransformer<any>} */
+  const transformer = ({ line, parsedOptions: { diff } }) => {
+    if (diff && line.text.startsWith('+ ')) {
+      return {
+        line: highlightDiffLine(line, 'add'),
+        data: { isDiffAdd: true }
+      };
+    }
+    if (diff && line.text.startsWith('- ')) {
+      return {
+        line: highlightDiffLine(line, 'del'),
+        data: { isDiffDel: true }
+      };
+    }
+    return { line };
+  };
+
+  transformer.displayName = 'diff';
+  transformer.schemaExtension = `
+    type GRVSCTokenizedLine {
+      isDiff: Boolean
+    }
+  `;
+
+  return transformer;
+}
+
+module.exports = { createDiffLineTransformer };

--- a/src/transformers/diffLineTransformer.js
+++ b/src/transformers/diffLineTransformer.js
@@ -6,10 +6,11 @@ function createDiffLineTransformer() {
   /** @type {LineTransformer<any>} */
   const diffLineTransformer = ({ line, meta: { diff } }) => {
     if (diff && line.text.startsWith('+ ')) {
-      line.text = line.text.replace(/^\+ /, '');
+      const text = line.text.replace(/^\+ /, '');
       return {
-        line: highlightDiffLine(line, 'add'),
-        data: { isDiffAdd: true },
+        line: highlightDiffLine({ ...line, text }, 'add'),
+        data: { diff: 'ADD' },
+        setContainerClassName: 'grvsc-has-line-highlighting',
         gutterCells: [
           {
             className: 'grvsc-diff-add',
@@ -19,10 +20,11 @@ function createDiffLineTransformer() {
       };
     }
     if (diff && line.text.startsWith('- ')) {
-      line.text = line.text.replace(/^\- /, '');
+      const text = line.text.replace(/^\- /, '');
       return {
-        line: highlightDiffLine(line, 'del'),
-        data: { isDiffDel: true },
+        line: highlightDiffLine({ ...line, text }, 'del'),
+        data: { diff: 'DEL' },
+        setContainerClassName: 'grvsc-has-line-highlighting',
         gutterCells: [
           {
             className: 'grvsc-diff-del',
@@ -36,8 +38,13 @@ function createDiffLineTransformer() {
 
   diffLineTransformer.displayName = 'diff';
   diffLineTransformer.schemaExtension = `
+    enum GRVSCDiff {
+      ADD
+      DEL
+    }
+
     type GRVSCTokenizedLine {
-      isDiff: Boolean
+      diff: GRVSCDiff
     }
   `;
 

--- a/src/transformers/diffLineTransformer.js
+++ b/src/transformers/diffLineTransformer.js
@@ -5,8 +5,8 @@ function createDiffLineTransformer() {
   // How do I get the parsed code fence options here?
   /** @type {LineTransformer<any>} */
   const diffLineTransformer = ({ line, meta: { diff } }) => {
-    if (diff && line.text.startsWith('+ ')) {
-      const text = line.text.replace(/^\+ /, '');
+    if (diff && line.text.startsWith('+')) {
+      const text = line.text.replace(/^\+ ?/, '');
       return {
         line: highlightDiffLine({ ...line, text }, 'add'),
         data: { diff: 'ADD' },
@@ -19,8 +19,8 @@ function createDiffLineTransformer() {
         ]
       };
     }
-    if (diff && line.text.startsWith('- ')) {
-      const text = line.text.replace(/^\- /, '');
+    if (diff && line.text.startsWith('-')) {
+      const text = line.text.replace(/^- ?/, '');
       return {
         line: highlightDiffLine({ ...line, text }, 'del'),
         data: { diff: 'DEL' },

--- a/src/transformers/diffLineTransformer.js
+++ b/src/transformers/diffLineTransformer.js
@@ -4,30 +4,44 @@ const { highlightDiffLine } = require('./transformerUtils');
 function createDiffLineTransformer() {
   // How do I get the parsed code fence options here?
   /** @type {LineTransformer<any>} */
-  const transformer = ({ line, parsedOptions: { diff } }) => {
+  const diffLineTransformer = ({ line, meta: { diff } }) => {
     if (diff && line.text.startsWith('+ ')) {
+      line.text = line.text.replace(/^\+ /, '');
       return {
         line: highlightDiffLine(line, 'add'),
-        data: { isDiffAdd: true }
+        data: { isDiffAdd: true },
+        gutterCells: [
+          {
+            className: 'grvsc-diff-add',
+            text: `+`
+          }
+        ]
       };
     }
     if (diff && line.text.startsWith('- ')) {
+      line.text = line.text.replace(/^\- /, '');
       return {
         line: highlightDiffLine(line, 'del'),
-        data: { isDiffDel: true }
+        data: { isDiffDel: true },
+        gutterCells: [
+          {
+            className: 'grvsc-diff-del',
+            text: `-`
+          }
+        ]
       };
     }
     return { line };
   };
 
-  transformer.displayName = 'diff';
-  transformer.schemaExtension = `
+  diffLineTransformer.displayName = 'diff';
+  diffLineTransformer.schemaExtension = `
     type GRVSCTokenizedLine {
       isDiff: Boolean
     }
   `;
 
-  return transformer;
+  return diffLineTransformer;
 }
 
 module.exports = { createDiffLineTransformer };

--- a/src/transformers/index.js
+++ b/src/transformers/index.js
@@ -2,6 +2,7 @@
 const { highlightMetaTransformer } = require('./highlightMetaTransformer');
 const { createHighlightDirectiveLineTransformer } = require('./highlightDirectiveLineTransformer');
 const { createLineNumberLineTransformer } = require('./lineNumberTransformer');
+const { createDiffLineTransformer } = require('./diffLineTransformer');
 const getTransformedLines = require('./getTransformedLines');
 
 /**
@@ -13,7 +14,8 @@ function getDefaultLineTransformers(pluginOptions, cache) {
   return [
     createHighlightDirectiveLineTransformer(pluginOptions.languageAliases, cache),
     highlightMetaTransformer,
-    createLineNumberLineTransformer(pluginOptions.languageAliases, cache)
+    createLineNumberLineTransformer(pluginOptions.languageAliases, cache),
+    createDiffLineTransformer()
   ];
 }
 

--- a/src/transformers/transformerUtils.js
+++ b/src/transformers/transformerUtils.js
@@ -74,4 +74,16 @@ function getCommentRegExp(scope) {
   }
 }
 
-module.exports = { highlightLine, addClassName, getCommentContent, getCommentRegExp };
+/**
+ * @param {LineTransformerArgs['line']} line
+ * @param {('add'|'del')} postfix
+ * @returns {LineTransformerArgs['line']}
+ */
+function highlightDiffLine(line, postfix) {
+  return {
+    attrs: addClassName(line.attrs, `grvsc-line-diff grvsc-line-diff-${postfix}`),
+    text: line.text
+  };
+}
+
+module.exports = { highlightLine, addClassName, getCommentContent, getCommentRegExp, highlightDiffLine };

--- a/src/transformers/transformerUtils.js
+++ b/src/transformers/transformerUtils.js
@@ -76,7 +76,7 @@ function getCommentRegExp(scope) {
 
 /**
  * @param {LineTransformerArgs['line']} line
- * @param {('add'|'del')} postfix
+ * @param {'add' | 'del'} postfix
  * @returns {LineTransformerArgs['line']}
  */
 function highlightDiffLine(line, postfix) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -60,9 +60,11 @@ function getExtensionPackageJson(identifier, extensionDir) {
  */
 function getLanguageNames(languageRegistration) {
   return uniq(
-    [languageRegistration.id, ...(languageRegistration.aliases || []), ...(languageRegistration.extensions || [])].map(
-      name => name.toLowerCase().replace(/[^a-z0-9_+#-]/g, '')
-    )
+    [
+      languageRegistration.id,
+      ...(languageRegistration.aliases || []),
+      ...(languageRegistration.extensions || [])
+    ].map(name => name.toLowerCase().replace(/[^a-z0-9_+#-]/g, ''))
   );
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -60,11 +60,9 @@ function getExtensionPackageJson(identifier, extensionDir) {
  */
 function getLanguageNames(languageRegistration) {
   return uniq(
-    [
-      languageRegistration.id,
-      ...(languageRegistration.aliases || []),
-      ...(languageRegistration.extensions || [])
-    ].map(name => name.toLowerCase().replace(/[^a-z0-9_+#-]/g, ''))
+    [languageRegistration.id, ...(languageRegistration.aliases || []), ...(languageRegistration.extensions || [])].map(
+      name => name.toLowerCase().replace(/[^a-z0-9_+#-]/g, '')
+    )
   );
 }
 

--- a/styles.css
+++ b/styles.css
@@ -66,7 +66,16 @@
 
 .grvsc-line-highlighted::before {
   background-color: var(--grvsc-line-highlighted-background-color, transparent);
-  box-shadow: inset var(--grvsc-line-highlighted-border-width, 4px) 0 0 0 var(--grvsc-line-highlighted-border-color, transparent);
+  box-shadow: inset var(--grvsc-line-highlighted-border-width, 4px) 0 0 0
+    var(--grvsc-line-highlighted-border-color, transparent);
+}
+
+.grvsc-line-diff-add {
+  background-color: var(--grvsc-line-diff-add-background-color, transparent);
+}
+
+.grvsc-line-diff-del {
+  background-color: var(--grvsc-line-diff-del-background-color, transparent);
 }
 
 .grvsc-line-number {

--- a/styles.css
+++ b/styles.css
@@ -66,8 +66,7 @@
 
 .grvsc-line-highlighted::before {
   background-color: var(--grvsc-line-highlighted-background-color, transparent);
-  box-shadow: inset var(--grvsc-line-highlighted-border-width, 4px) 0 0 0
-    var(--grvsc-line-highlighted-border-color, transparent);
+  box-shadow: inset var(--grvsc-line-highlighted-border-width, 4px) 0 0 0 var(--grvsc-line-highlighted-border-color, transparent);
 }
 
 .grvsc-line-diff-add::before {

--- a/styles.css
+++ b/styles.css
@@ -70,12 +70,12 @@
     var(--grvsc-line-highlighted-border-color, transparent);
 }
 
-.grvsc-line-diff-add {
-  background-color: var(--grvsc-line-diff-add-background-color, transparent);
+.grvsc-line-diff-add::before {
+  background-color: var(--grvsc-line-diff-add-background-color, rgba(0, 255, 60, 0.4));
 }
 
-.grvsc-line-diff-del {
-  background-color: var(--grvsc-line-diff-del-background-color, transparent);
+.grvsc-line-diff-del::before {
+  background-color: var(--grvsc-line-diff-del-background-color, rgba(255, 0, 20, 0.4));
 }
 
 .grvsc-line-number {

--- a/test/integration/baselines/bug-37.html
+++ b/test/integration/baselines/bug-37.html
@@ -81,11 +81,20 @@
     box-shadow: inset var(--grvsc-line-highlighted-border-width, 4px) 0 0 0 var(--grvsc-line-highlighted-border-color, transparent);
   }
   
+  .grvsc-line-diff-add::before {
+    background-color: var(--grvsc-line-diff-add-background-color, rgba(0, 255, 60, 0.4));
+  }
+  
+  .grvsc-line-diff-del::before {
+    background-color: var(--grvsc-line-diff-del-background-color, rgba(255, 0, 20, 0.4));
+  }
+  
   .grvsc-line-number {
     padding: 0 2px;
     text-align: right;
     opacity: 0.7;
   }
+  
   .default-dark {
     background-color: #1E1E1E;
     color: #D4D4D4;

--- a/test/integration/baselines/bug-93.html
+++ b/test/integration/baselines/bug-93.html
@@ -80,11 +80,20 @@
     box-shadow: inset var(--grvsc-line-highlighted-border-width, 4px) 0 0 0 var(--grvsc-line-highlighted-border-color, transparent);
   }
   
+  .grvsc-line-diff-add::before {
+    background-color: var(--grvsc-line-diff-add-background-color, rgba(0, 255, 60, 0.4));
+  }
+  
+  .grvsc-line-diff-del::before {
+    background-color: var(--grvsc-line-diff-del-background-color, rgba(255, 0, 20, 0.4));
+  }
+  
   .grvsc-line-number {
     padding: 0 2px;
     text-align: right;
     opacity: 0.7;
   }
+  
   .default-dark {
     background-color: #1E1E1E;
     color: #D4D4D4;

--- a/test/integration/baselines/code-fence-meta.html
+++ b/test/integration/baselines/code-fence-meta.html
@@ -72,11 +72,20 @@
     box-shadow: inset var(--grvsc-line-highlighted-border-width, 4px) 0 0 0 var(--grvsc-line-highlighted-border-color, transparent);
   }
   
+  .grvsc-line-diff-add::before {
+    background-color: var(--grvsc-line-diff-add-background-color, rgba(0, 255, 60, 0.4));
+  }
+  
+  .grvsc-line-diff-del::before {
+    background-color: var(--grvsc-line-diff-del-background-color, rgba(255, 0, 20, 0.4));
+  }
+  
   .grvsc-line-number {
     padding: 0 2px;
     text-align: right;
     opacity: 0.7;
   }
+  
   .default-dark {
     background-color: #1E1E1E;
     color: #D4D4D4;

--- a/test/integration/baselines/diff-highlighting.html
+++ b/test/integration/baselines/diff-highlighting.html
@@ -1,5 +1,7 @@
 <pre class="grvsc-container grvsc-has-line-highlighting default-dark" data-language="ts" data-index="0"><code class="grvsc-code"><span class="grvsc-line grvsc-line-diff grvsc-line-diff-add"><span class="grvsc-gutter-pad"></span><span class="grvsc-gutter grvsc-diff-add" aria-hidden="true" data-content="+"></span><span class="grvsc-source"><span class="mtk4">const</span><span class="mtk1"> </span><span class="mtk12">x</span><span class="mtk1"> = </span><span class="mtk7">1</span><span class="mtk1">;</span></span></span>
-<span class="grvsc-line grvsc-line-diff grvsc-line-diff-del"><span class="grvsc-gutter-pad"></span><span class="grvsc-gutter grvsc-diff-del" aria-hidden="true" data-content="-"></span><span class="grvsc-source"><span class="mtk4">const</span><span class="mtk1"> </span><span class="mtk12">y</span><span class="mtk1"> = </span><span class="mtk7">2</span><span class="mtk1">;</span></span></span></code></pre>
+<span class="grvsc-line grvsc-line-diff grvsc-line-diff-del"><span class="grvsc-gutter-pad"></span><span class="grvsc-gutter grvsc-diff-del" aria-hidden="true" data-content="-"></span><span class="grvsc-source"><span class="mtk4">const</span><span class="mtk1"> </span><span class="mtk12">y</span><span class="mtk1"> = </span><span class="mtk7">2</span><span class="mtk1">;</span></span></span>
+<span class="grvsc-line grvsc-line-diff grvsc-line-diff-add"><span class="grvsc-gutter-pad"></span><span class="grvsc-gutter grvsc-diff-add" aria-hidden="true" data-content="+"></span><span class="grvsc-source"><span class="mtk4">const</span><span class="mtk1"> </span><span class="mtk12">a</span><span class="mtk1"> = </span><span class="mtk8">'a'</span><span class="mtk1">;</span></span></span>
+<span class="grvsc-line grvsc-line-diff grvsc-line-diff-del"><span class="grvsc-gutter-pad"></span><span class="grvsc-gutter grvsc-diff-del" aria-hidden="true" data-content="-"></span><span class="grvsc-source"><span class="mtk4">const</span><span class="mtk1"> </span><span class="mtk12">b</span><span class="mtk1"> = </span><span class="mtk8">'b'</span><span class="mtk1">;</span></span></span></code></pre>
 <style class="grvsc-styles">
   .grvsc-container {
     overflow: auto;
@@ -94,4 +96,5 @@
   .default-dark .mtk1 { color: #D4D4D4; }
   .default-dark .mtk12 { color: #9CDCFE; }
   .default-dark .mtk7 { color: #B5CEA8; }
+  .default-dark .mtk8 { color: #CE9178; }
 </style>

--- a/test/integration/baselines/diff-highlighting.html
+++ b/test/integration/baselines/diff-highlighting.html
@@ -1,5 +1,5 @@
-<pre class="grvsc-container default-dark" data-language="ts" data-index="0"><code class="grvsc-code"><span class="grvsc-line grvsc-line-diff grvsc-line-diff-add"><span class="mtk1">+ </span><span class="mtk4">const</span><span class="mtk1"> </span><span class="mtk12">x</span><span class="mtk1"> = </span><span class="mtk7">1</span><span class="mtk1">;</span></span>
-<span class="grvsc-line grvsc-line-diff grvsc-line-diff-del"><span class="mtk1">- </span><span class="mtk4">const</span><span class="mtk1"> </span><span class="mtk12">y</span><span class="mtk1"> = </span><span class="mtk7">2</span><span class="mtk1">;</span></span></code></pre>
+<pre class="grvsc-container grvsc-has-line-highlighting default-dark" data-language="ts" data-index="0"><code class="grvsc-code"><span class="grvsc-line grvsc-line-diff grvsc-line-diff-add"><span class="grvsc-gutter-pad"></span><span class="grvsc-gutter grvsc-diff-add" aria-hidden="true" data-content="+"></span><span class="grvsc-source"><span class="mtk4">const</span><span class="mtk1"> </span><span class="mtk12">x</span><span class="mtk1"> = </span><span class="mtk7">1</span><span class="mtk1">;</span></span></span>
+<span class="grvsc-line grvsc-line-diff grvsc-line-diff-del"><span class="grvsc-gutter-pad"></span><span class="grvsc-gutter grvsc-diff-del" aria-hidden="true" data-content="-"></span><span class="grvsc-source"><span class="mtk4">const</span><span class="mtk1"> </span><span class="mtk12">y</span><span class="mtk1"> = </span><span class="mtk7">2</span><span class="mtk1">;</span></span></span></code></pre>
 <style class="grvsc-styles">
   .grvsc-container {
     overflow: auto;
@@ -11,43 +11,87 @@
     border-radius: 8px;
     border-radius: var(--grvsc-border-radius, 8px);
     font-feature-settings: normal;
+    line-height: 1.4;
   }
   
   .grvsc-code {
-    display: inline-block;
-    min-width: 100%;
+    display: table;
   }
   
   .grvsc-line {
-    display: inline-block;
+    display: table-row;
     box-sizing: border-box;
     width: 100%;
+    position: relative;
+  }
+  
+  .grvsc-line > * {
+    position: relative;
+  }
+  
+  .grvsc-gutter-pad {
+    display: table-cell;
+    padding-left: 0.75rem;
+    padding-left: calc(var(--grvsc-padding-left, var(--grvsc-padding-h, 1.5rem)) / 2);
+  }
+  
+  .grvsc-gutter {
+    display: table-cell;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    user-select: none;
+  }
+  
+  .grvsc-gutter::before {
+    content: attr(data-content);
+  }
+  
+  .grvsc-source {
+    display: table-cell;
     padding-left: 1.5rem;
     padding-left: var(--grvsc-padding-left, var(--grvsc-padding-h, 1.5rem));
     padding-right: 1.5rem;
     padding-right: var(--grvsc-padding-right, var(--grvsc-padding-h, 1.5rem));
   }
   
-  .grvsc-line-highlighted {
+  .grvsc-gutter + .grvsc-source {
+    padding-left: 0.75rem;
+    padding-left: calc(var(--grvsc-padding-left, var(--grvsc-padding-h, 1.5rem)) / 2);
+  }
+  
+  /* Line transformer styles */
+  
+  .grvsc-has-line-highlighting > .grvsc-code > .grvsc-line::before {
+    content: ' ';
+    position: absolute;
+    width: 100%;
+  }
+  
+  .grvsc-line-highlighted::before {
     background-color: var(--grvsc-line-highlighted-background-color, transparent);
-    box-shadow: inset var(--grvsc-line-highlighted-border-width, 4px) 0 0 0
-      var(--grvsc-line-highlighted-border-color, transparent);
+    box-shadow: inset var(--grvsc-line-highlighted-border-width, 4px) 0 0 0 var(--grvsc-line-highlighted-border-color, transparent);
   }
   
-  .grvsc-line-diff-add {
-    background-color: var(--grvsc-line-diff-add-background-color, transparent);
+  .grvsc-line-diff-add::before {
+    background-color: var(--grvsc-line-diff-add-background-color, rgba(0, 255, 60, 0.4));
   }
   
-  .grvsc-line-diff-del {
-    background-color: var(--grvsc-line-diff-del-background-color, transparent);
+  .grvsc-line-diff-del::before {
+    background-color: var(--grvsc-line-diff-del-background-color, rgba(255, 0, 20, 0.4));
+  }
+  
+  .grvsc-line-number {
+    padding: 0 2px;
+    text-align: right;
+    opacity: 0.7;
   }
   
   .default-dark {
     background-color: #1E1E1E;
     color: #D4D4D4;
   }
-  .default-dark .mtk1 { color: #D4D4D4; }
   .default-dark .mtk4 { color: #569CD6; }
+  .default-dark .mtk1 { color: #D4D4D4; }
   .default-dark .mtk12 { color: #9CDCFE; }
   .default-dark .mtk7 { color: #B5CEA8; }
 </style>

--- a/test/integration/baselines/diff-highlighting.html
+++ b/test/integration/baselines/diff-highlighting.html
@@ -1,0 +1,53 @@
+<pre class="grvsc-container default-dark" data-language="ts" data-index="0"><code class="grvsc-code"><span class="grvsc-line grvsc-line-diff grvsc-line-diff-add"><span class="mtk1">+ </span><span class="mtk4">const</span><span class="mtk1"> </span><span class="mtk12">x</span><span class="mtk1"> = </span><span class="mtk7">1</span><span class="mtk1">;</span></span>
+<span class="grvsc-line grvsc-line-diff grvsc-line-diff-del"><span class="mtk1">- </span><span class="mtk4">const</span><span class="mtk1"> </span><span class="mtk12">y</span><span class="mtk1"> = </span><span class="mtk7">2</span><span class="mtk1">;</span></span></code></pre>
+<style class="grvsc-styles">
+  .grvsc-container {
+    overflow: auto;
+    -webkit-overflow-scrolling: touch;
+    padding-top: 1rem;
+    padding-top: var(--grvsc-padding-top, var(--grvsc-padding-v, 1rem));
+    padding-bottom: 1rem;
+    padding-bottom: var(--grvsc-padding-bottom, var(--grvsc-padding-v, 1rem));
+    border-radius: 8px;
+    border-radius: var(--grvsc-border-radius, 8px);
+    font-feature-settings: normal;
+  }
+  
+  .grvsc-code {
+    display: inline-block;
+    min-width: 100%;
+  }
+  
+  .grvsc-line {
+    display: inline-block;
+    box-sizing: border-box;
+    width: 100%;
+    padding-left: 1.5rem;
+    padding-left: var(--grvsc-padding-left, var(--grvsc-padding-h, 1.5rem));
+    padding-right: 1.5rem;
+    padding-right: var(--grvsc-padding-right, var(--grvsc-padding-h, 1.5rem));
+  }
+  
+  .grvsc-line-highlighted {
+    background-color: var(--grvsc-line-highlighted-background-color, transparent);
+    box-shadow: inset var(--grvsc-line-highlighted-border-width, 4px) 0 0 0
+      var(--grvsc-line-highlighted-border-color, transparent);
+  }
+  
+  .grvsc-line-diff-add {
+    background-color: var(--grvsc-line-diff-add-background-color, transparent);
+  }
+  
+  .grvsc-line-diff-del {
+    background-color: var(--grvsc-line-diff-del-background-color, transparent);
+  }
+  
+  .default-dark {
+    background-color: #1E1E1E;
+    color: #D4D4D4;
+  }
+  .default-dark .mtk1 { color: #D4D4D4; }
+  .default-dark .mtk4 { color: #569CD6; }
+  .default-dark .mtk12 { color: #9CDCFE; }
+  .default-dark .mtk7 { color: #B5CEA8; }
+</style>

--- a/test/integration/baselines/github-zip.html
+++ b/test/integration/baselines/github-zip.html
@@ -78,11 +78,20 @@
     box-shadow: inset var(--grvsc-line-highlighted-border-width, 4px) 0 0 0 var(--grvsc-line-highlighted-border-color, transparent);
   }
   
+  .grvsc-line-diff-add::before {
+    background-color: var(--grvsc-line-diff-add-background-color, rgba(0, 255, 60, 0.4));
+  }
+  
+  .grvsc-line-diff-del::before {
+    background-color: var(--grvsc-line-diff-del-background-color, rgba(255, 0, 20, 0.4));
+  }
+  
   .grvsc-line-number {
     padding: 0 2px;
     text-align: right;
     opacity: 0.7;
   }
+  
   .oceanic-plus {
     background-color: #1b2b34;
     color: #cdd3de;

--- a/test/integration/baselines/highlight-directive-comments.html
+++ b/test/integration/baselines/highlight-directive-comments.html
@@ -86,11 +86,20 @@
     box-shadow: inset var(--grvsc-line-highlighted-border-width, 4px) 0 0 0 var(--grvsc-line-highlighted-border-color, transparent);
   }
   
+  .grvsc-line-diff-add::before {
+    background-color: var(--grvsc-line-diff-add-background-color, rgba(0, 255, 60, 0.4));
+  }
+  
+  .grvsc-line-diff-del::before {
+    background-color: var(--grvsc-line-diff-del-background-color, rgba(255, 0, 20, 0.4));
+  }
+  
   .grvsc-line-number {
     padding: 0 2px;
     text-align: right;
     opacity: 0.7;
   }
+  
   .default-dark {
     background-color: #1E1E1E;
     color: #D4D4D4;

--- a/test/integration/baselines/inline-custom-class.html
+++ b/test/integration/baselines/inline-custom-class.html
@@ -75,11 +75,20 @@
     box-shadow: inset var(--grvsc-line-highlighted-border-width, 4px) 0 0 0 var(--grvsc-line-highlighted-border-color, transparent);
   }
   
+  .grvsc-line-diff-add::before {
+    background-color: var(--grvsc-line-diff-add-background-color, rgba(0, 255, 60, 0.4));
+  }
+  
+  .grvsc-line-diff-del::before {
+    background-color: var(--grvsc-line-diff-del-background-color, rgba(255, 0, 20, 0.4));
+  }
+  
   .grvsc-line-number {
     padding: 0 2px;
     text-align: right;
     opacity: 0.7;
   }
+  
   .default-light {
     background-color: #FFFFFF;
     color: #000000;

--- a/test/integration/baselines/inline-theme-function.html
+++ b/test/integration/baselines/inline-theme-function.html
@@ -75,11 +75,20 @@
     box-shadow: inset var(--grvsc-line-highlighted-border-width, 4px) 0 0 0 var(--grvsc-line-highlighted-border-color, transparent);
   }
   
+  .grvsc-line-diff-add::before {
+    background-color: var(--grvsc-line-diff-add-background-color, rgba(0, 255, 60, 0.4));
+  }
+  
+  .grvsc-line-diff-del::before {
+    background-color: var(--grvsc-line-diff-del-background-color, rgba(255, 0, 20, 0.4));
+  }
+  
   .grvsc-line-number {
     padding: 0 2px;
     text-align: right;
     opacity: 0.7;
   }
+  
   .abyss { background-color: #000c18; }
   .abyss .mtki { font-style: italic; }
   .abyss .mtk6 { color: #DDBB88; }

--- a/test/integration/baselines/inline.html
+++ b/test/integration/baselines/inline.html
@@ -75,11 +75,20 @@
     box-shadow: inset var(--grvsc-line-highlighted-border-width, 4px) 0 0 0 var(--grvsc-line-highlighted-border-color, transparent);
   }
   
+  .grvsc-line-diff-add::before {
+    background-color: var(--grvsc-line-diff-add-background-color, rgba(0, 255, 60, 0.4));
+  }
+  
+  .grvsc-line-diff-del::before {
+    background-color: var(--grvsc-line-diff-del-background-color, rgba(255, 0, 20, 0.4));
+  }
+  
   .grvsc-line-number {
     padding: 0 2px;
     text-align: right;
     opacity: 0.7;
   }
+  
   .default-light {
     background-color: #FFFFFF;
     color: #000000;

--- a/test/integration/baselines/line-numbers.html
+++ b/test/integration/baselines/line-numbers.html
@@ -101,11 +101,20 @@
     box-shadow: inset var(--grvsc-line-highlighted-border-width, 4px) 0 0 0 var(--grvsc-line-highlighted-border-color, transparent);
   }
   
+  .grvsc-line-diff-add::before {
+    background-color: var(--grvsc-line-diff-add-background-color, rgba(0, 255, 60, 0.4));
+  }
+  
+  .grvsc-line-diff-del::before {
+    background-color: var(--grvsc-line-diff-del-background-color, rgba(255, 0, 20, 0.4));
+  }
+  
   .grvsc-line-number {
     padding: 0 2px;
     text-align: right;
     opacity: 0.7;
   }
+  
   .default-dark {
     background-color: #1E1E1E;
     color: #D4D4D4;

--- a/test/integration/baselines/npm-extension.html
+++ b/test/integration/baselines/npm-extension.html
@@ -78,11 +78,20 @@
     box-shadow: inset var(--grvsc-line-highlighted-border-width, 4px) 0 0 0 var(--grvsc-line-highlighted-border-color, transparent);
   }
   
+  .grvsc-line-diff-add::before {
+    background-color: var(--grvsc-line-diff-add-background-color, rgba(0, 255, 60, 0.4));
+  }
+  
+  .grvsc-line-diff-del::before {
+    background-color: var(--grvsc-line-diff-del-background-color, rgba(255, 0, 20, 0.4));
+  }
+  
   .grvsc-line-number {
     padding: 0 2px;
     text-align: right;
     opacity: 0.7;
   }
+  
   .synthwave-vscode { background-color: #262335; }
   .synthwave-vscode .mtki { font-style: italic; }
   .synthwave-vscode .mtk4 { color: #495495; }

--- a/test/integration/baselines/parent-selector.html
+++ b/test/integration/baselines/parent-selector.html
@@ -71,11 +71,20 @@
     box-shadow: inset var(--grvsc-line-highlighted-border-width, 4px) 0 0 0 var(--grvsc-line-highlighted-border-color, transparent);
   }
   
+  .grvsc-line-diff-add::before {
+    background-color: var(--grvsc-line-diff-add-background-color, rgba(0, 255, 60, 0.4));
+  }
+  
+  .grvsc-line-diff-del::before {
+    background-color: var(--grvsc-line-diff-del-background-color, rgba(255, 0, 20, 0.4));
+  }
+  
   .grvsc-line-number {
     padding: 0 2px;
     text-align: right;
     opacity: 0.7;
   }
+  
   .default-light {
     background-color: #FFFFFF;
     color: #000000;

--- a/test/integration/baselines/vsix.html
+++ b/test/integration/baselines/vsix.html
@@ -78,11 +78,20 @@
     box-shadow: inset var(--grvsc-line-highlighted-border-width, 4px) 0 0 0 var(--grvsc-line-highlighted-border-color, transparent);
   }
   
+  .grvsc-line-diff-add::before {
+    background-color: var(--grvsc-line-diff-add-background-color, rgba(0, 255, 60, 0.4));
+  }
+  
+  .grvsc-line-diff-del::before {
+    background-color: var(--grvsc-line-diff-del-background-color, rgba(255, 0, 20, 0.4));
+  }
+  
   .grvsc-line-number {
     padding: 0 2px;
     text-align: right;
     opacity: 0.7;
   }
+  
   .one-dark-pro {
     background-color: #282c34;
     color: #abb2bf;

--- a/test/integration/cases/diff-highlighting/test.md
+++ b/test/integration/cases/diff-highlighting/test.md
@@ -1,0 +1,4 @@
+```ts {diff}
++ const x = 1;
+- const y = 2;
+```

--- a/test/integration/cases/diff-highlighting/test.md
+++ b/test/integration/cases/diff-highlighting/test.md
@@ -1,4 +1,6 @@
 ```ts {diff}
 + const x = 1;
 - const y = 2;
++const a = 'a';
+-const b = 'b';
 ```

--- a/test/integration/viewer/render.js
+++ b/test/integration/viewer/render.js
@@ -51,6 +51,8 @@ function renderInIframe(html) {
             --grvsc-line-highlighted-background-color: rgba(255, 255, 255, 0.2); /* default: transparent */
             --grvsc-line-highlighted-border-color: rgba(255, 255, 255, 0.5); /* default: transparent */
             --grvsc-line-highlighted-border-width: 2px; /* default: 2px */
+            --grvsc-line-diff-add-background-color: rgba(0, 255, 0, 0.2); /* default: transparent */
+            --grvsc-line-diff-del-background-color: rgba(255, 0, 0, 0.2); /* default: transparent */
           }
         </style>
       </head>


### PR DESCRIPTION
Closes #62.

This is a draft implementation of a line transformer that enables diff highlighting on code fences with the [`{diff}` option](https://github.com/andrewbranch/gatsby-remark-vscode/pull/88/files#diff-6887d09d163fd4e53b30ba2ab651343fR1).

- Lines starting with `+ `&thinsp;indicate additions and can be highlighted with a green transparent background.
- Lines starting with `- `&thinsp;indicate deletions and can be highlighted with a red transparent background.

This seems like a very common use case to me so I took the liberty of [including `createDiffLineTransformer` in `getDefaultLineTransformers`](https://github.com/andrewbranch/gatsby-remark-vscode/pull/88/files#diff-0797f8b54e6ed443744041853b3e38efR16). Of course, feel free to undo that if you think this is more niche.

Also, due to my complete lack of JSDoc knowledege, I'd like to appeal to [`CONTRIBUTING.md`](https://github.com/andrewbranch/gatsby-remark-vscode/blob/master/CONTRIBUTING.md) which states:
> If types are new to you, or you have trouble getting type checking to pass, that’s ok! I’ll help you in your PR if necessary.

Specifically, I'm having trouble with the [type declaration on the transformer returned by `createDiffLineTransformer`](https://github.com/andrewbranch/gatsby-remark-vscode/pull/88/files#diff-939de1f342ea398f64eba69a09dae4b0R6).

Finally (not sure if the infrastructure for this is implemented yet), [how do I access a code fence's`parsedOptions` in a line transformer](https://github.com/andrewbranch/gatsby-remark-vscode/pull/88/files#diff-939de1f342ea398f64eba69a09dae4b0R7)?

```js
const transformer = ({ line, parsedOptions: { diff } }) => { ... }
```

ain't working.