### PR TITLE
Code span highlighting

### DIFF
--- a/src/createCodeNodeRegistry.js
+++ b/src/createCodeNodeRegistry.js
@@ -35,7 +35,8 @@ function createCodeNodeRegistry({ prefixAllClassNames } = {}) {
     forEachLine: (node, action) => blockMap.get(node).lines.forEach(action),
     forEachToken: (node, lineIndex, tokenAction) => {
       generateClassNames();
-      const { tokenizationResults, isTokenized, lines } = blockMap.get(node);
+      const map = node.type === 'code' ? blockMap : spanMap;
+      const { tokenizationResults, isTokenized, lines } = map.get(node);
       if (!isTokenized) {
         return;
       }

--- a/src/createCodeNodeRegistry.js
+++ b/src/createCodeNodeRegistry.js
@@ -6,10 +6,10 @@ const { declaration } = require('./renderers/css');
 
 /**
  * @template TKey
- * @param {CodeBlockRegistryOptions=} options
- * @returns {CodeBlockRegistry<TKey>}
+ * @param {CodeNodeRegistryOptions=} options
+ * @returns {CodeNodeRegistry<TKey>}
  */
-function createCodeBlockRegistry({ prefixAllClassNames } = {}) {
+function createCodeNodeRegistry({ prefixAllClassNames } = {}) {
   /** @type {Map<TKey, RegisteredCodeBlockData & { index: number }>} */
   const nodeMap = new Map();
   /** @type {ConditionalTheme[]} */
@@ -81,7 +81,7 @@ function createCodeBlockRegistry({ prefixAllClassNames } = {}) {
     forEachCodeBlock: nodeMap.forEach.bind(nodeMap),
     getAllPossibleThemes: () => themes.map(theme => ({ theme, settings: themeColors.get(theme.identifier).settings })),
     getTokenStylesForTheme: themeIdentifier => {
-      /** @type {ReturnType<CodeBlockRegistry['getTokenStylesForTheme']>} */
+      /** @type {ReturnType<CodeNodeRegistry['getTokenStylesForTheme']>} */
       const result = [];
       const colors = themeColors.get(themeIdentifier);
       const classNameMap = themeTokenClassNameMap && themeTokenClassNameMap.get(themeIdentifier);
@@ -202,4 +202,4 @@ function getColorFromColorMap(colorMap, canonicalClassName) {
   return colorMap[index];
 }
 
-module.exports = createCodeBlockRegistry;
+module.exports = createCodeNodeRegistry;

--- a/src/factory/html.js
+++ b/src/factory/html.js
@@ -34,6 +34,18 @@ function createLineElement(line, meta, index, language, getLineClassName, tokens
 }
 
 /**
+ * @param {number} index
+ * @param {string} language
+ * @param {string | undefined} className
+ * @param {grvsc.HTMLElement[]} tokens
+ */
+function createCodeSpanElement(index, language, className, tokens) {
+  return code({ class: className, 'data-language': language, 'data-index': index }, tokens, {
+    whitespace: TriviaRenderFlags.NoWhitespace
+  });
+}
+
+/**
  * Returns the token element array with contiguous spans having the same class name
  * merged into a single span to minimize the number of elements returned.
  * @param {grvsc.HTMLElement[]} tokenElements
@@ -90,5 +102,6 @@ module.exports = {
   createTokenElement,
   createLineElement,
   createCodeBlockElement,
-  createStyleElement
+  createStyleElement,
+  createCodeSpanElement
 };

--- a/src/getPossibleThemes.js
+++ b/src/getPossibleThemes.js
@@ -14,19 +14,9 @@ const {
  * @param {T} codeNodeData
  * @returns {Promise<ConditionalTheme[]>}
  */
-async function getPossibleThemes(
-  themeOption,
-  themeCache,
-  contextDirectory,
-  codeNodeData
-) {
+async function getPossibleThemes(themeOption, themeCache, contextDirectory, codeNodeData) {
   if (typeof themeOption === 'function') {
-    return getPossibleThemes(
-      themeOption(codeNodeData),
-      themeCache,
-      contextDirectory,
-      codeNodeData
-    );
+    return getPossibleThemes(themeOption(codeNodeData), themeCache, contextDirectory, codeNodeData);
   }
 
   if (typeof themeOption === 'string') {
@@ -36,12 +26,7 @@ async function getPossibleThemes(
   /** @type {ConditionalTheme[]} */
   let themes;
   if (themeOption.default) {
-    themes = await getPossibleThemes(
-      themeOption.default,
-      themeCache,
-      contextDirectory,
-      codeNodeData
-    );
+    themes = await getPossibleThemes(themeOption.default, themeCache, contextDirectory, codeNodeData);
   }
   if (themeOption.dark) {
     themes = concatConditionalThemes(themes, [

--- a/src/getPossibleThemes.js
+++ b/src/getPossibleThemes.js
@@ -7,38 +7,25 @@ const {
 } = require('./themeUtils');
 
 /**
- * @param {ThemeOption} themeOption
+ * @template {CodeBlockData | CodeSpanData} T
+ * @param {ThemeOption<T>} themeOption
  * @param {ThemeCache} themeCache
  * @param {string | undefined} contextDirectory
- * @param {MarkdownNode} markdownNode
- * @param {MDASTNode} codeFenceNode
- * @param {string} languageName
- * @param {object} meta
+ * @param {T} codeNodeData
  * @returns {Promise<ConditionalTheme[]>}
  */
 async function getPossibleThemes(
   themeOption,
   themeCache,
   contextDirectory,
-  markdownNode,
-  codeFenceNode,
-  languageName,
-  meta
+  codeNodeData
 ) {
   if (typeof themeOption === 'function') {
     return getPossibleThemes(
-      themeOption({
-        markdownNode,
-        codeFenceNode,
-        language: languageName,
-        parsedOptions: meta
-      }),
+      themeOption(codeNodeData),
       themeCache,
       contextDirectory,
-      markdownNode,
-      codeFenceNode,
-      languageName,
-      meta
+      codeNodeData
     );
   }
 
@@ -53,10 +40,7 @@ async function getPossibleThemes(
       themeOption.default,
       themeCache,
       contextDirectory,
-      markdownNode,
-      codeFenceNode,
-      languageName,
-      meta
+      codeNodeData
     );
   }
   if (themeOption.dark) {

--- a/src/graphql/getCodeBlockDataFromRegistry.js
+++ b/src/graphql/getCodeBlockDataFromRegistry.js
@@ -5,10 +5,10 @@ const { flatMap, partitionOne, escapeHTML } = require('../utils');
 const { createTokenElement, createLineElement, createCodeBlockElement } = require('../factory/html');
 
 /**
- * @template TKey
+ * @template {Keyable} TKey
  * @param {CodeNodeRegistry<TKey>} registry
  * @param {TKey} key
- * @param {RegisteredCodeBlockData} codeBlock
+ * @param {RegisteredCodeNodeData} codeBlock
  * @param {() => string} getWrapperClassName
  * @param {(line: LineData) => string} getLineClassName
  * @returns {Omit<grvsc.gql.GRVSCCodeBlock, 'id'>}

--- a/src/graphql/getCodeBlockDataFromRegistry.js
+++ b/src/graphql/getCodeBlockDataFromRegistry.js
@@ -6,7 +6,7 @@ const { createTokenElement, createLineElement, createCodeBlockElement } = requir
 
 /**
  * @template TKey
- * @param {CodeBlockRegistry<TKey>} registry
+ * @param {CodeNodeRegistry<TKey>} registry
  * @param {TKey} key
  * @param {RegisteredCodeBlockData} codeBlock
  * @param {() => string} getWrapperClassName

--- a/src/graphql/getCodeSpanDataFromRegistry.js
+++ b/src/graphql/getCodeSpanDataFromRegistry.js
@@ -1,0 +1,48 @@
+const { renderHTML } = require('../renderers/html');
+const { partitionOne } = require('../utils');
+const { createTokenElement, createCodeSpanElement } = require('../factory/html');
+
+/**
+ * @template {Keyable} TKey
+ * @param {CodeNodeRegistry<TKey>} registry
+ * @param {TKey} key
+ * @param {RegisteredCodeNodeData} codeSpan
+ * @param {() => string} getClassName
+ * @returns {Omit<grvsc.gql.GRVSCCodeSpan, 'id'>}
+ */
+function getCodeSpanDataFromRegistry(registry, key, codeSpan, getClassName) {
+  const { index, languageName, text, possibleThemes } = codeSpan;
+  /** @type {grvsc.HTMLElement[]} */
+  const tokenElements = [];
+  /** @type {grvsc.gql.GRVSCToken[]} */
+  const gqlTokens = [];
+
+  registry.forEachToken(key, 0, token => {
+    const html = createTokenElement(token);
+    tokenElements.push(html);
+    gqlTokens.push({
+      ...token,
+      className: html.attributes.class,
+      html: renderHTML(html)
+    });
+  });
+
+  const className = getClassName();
+  const html = createCodeSpanElement(index, languageName, className, tokenElements);
+  const [defaultTheme, additionalThemes] = partitionOne(possibleThemes, t =>
+    t.conditions.some(c => c.condition === 'default')
+  );
+
+  return {
+    index,
+    text,
+    html: renderHTML(html),
+    language: languageName,
+    className: getClassName(),
+    defaultTheme,
+    additionalThemes,
+    tokens: gqlTokens
+  };
+}
+
+module.exports = getCodeSpanDataFromRegistry;

--- a/src/graphql/getCodeSpanDataFromRegistry.js
+++ b/src/graphql/getCodeSpanDataFromRegistry.js
@@ -1,6 +1,8 @@
 const { renderHTML } = require('../renderers/html');
-const { partitionOne } = require('../utils');
+const { partitionOne, flatMap } = require('../utils');
 const { createTokenElement, createCodeSpanElement } = require('../factory/html');
+const { getThemeClassNames } = require('../themeUtils');
+const { joinClassNames } = require('../renderers/css');
 
 /**
  * @template {Keyable} TKey
@@ -27,7 +29,9 @@ function getCodeSpanDataFromRegistry(registry, key, codeSpan, getClassName) {
     });
   });
 
-  const className = getClassName();
+  const customClassName = getClassName();
+  const themeClassNames = flatMap(possibleThemes, getThemeClassNames);
+  const className = joinClassNames(customClassName, ...themeClassNames);
   const html = createCodeSpanElement(index, languageName, className, tokenElements);
   const [defaultTheme, additionalThemes] = partitionOne(possibleThemes, t =>
     t.conditions.some(c => c.condition === 'default')

--- a/src/graphql/getThemes.js
+++ b/src/graphql/getThemes.js
@@ -17,7 +17,7 @@ async function convertThemeArgument(theme, themeCache) {
 }
 
 /**
- * @param {ThemeOption} themeOption
+ * @param {ThemeOption<CodeBlockData | CodeSpanData>} themeOption
  * @param {grvsc.gql.CSSArgs} args
  * @param {ThemeCache} themeCache
  * @returns {Promise<ConditionalTheme[]>}
@@ -40,7 +40,7 @@ async function getThemes(themeOption, args, themeCache) {
         `evaluating 'grvscHighlight'.`
     );
   }
-  return getPossibleThemes(themeOption, themeCache, undefined, undefined, undefined, undefined, undefined);
+  return getPossibleThemes(themeOption, themeCache, undefined, undefined);
 }
 
 module.exports = getThemes;

--- a/src/graphql/highlight.js
+++ b/src/graphql/highlight.js
@@ -40,7 +40,7 @@ async function highlight(args, pluginOptions, { cache, createNodeId }) {
   const grammarCache = await cache.get('grammars');
   const possibleThemes = await getThemes(theme, args, themeCache);
   const scope = getScope(args.language, grammarCache, languageAliases);
-  /** @type {CodeBlockRegistry<typeof registryKey>} */
+  /** @type {CodeNodeRegistry<typeof registryKey>} */
   const codeBlockRegistry = createCodeBlockRegistry({ prefixAllClassNames: true });
   const meta = parseCodeFenceHeader(args.language, args.meta);
 

--- a/src/graphql/schema.d.ts
+++ b/src/graphql/schema.d.ts
@@ -48,6 +48,16 @@ declare namespace grvsc {
             additionalThemes: GRVSCTheme[];
             tokenizedLines?: GRVSCTokenizedLine[];
         }
+        interface GRVSCCodeSpan extends Node {
+            index: number;
+            html: string;
+            text: string;
+            className: string;
+            language?: string;
+            defaultTheme: GRVSCTheme;
+            additionalThemes: GRVSCTheme[];
+            tokens: GRVSCToken[];
+        }
         interface GRVSCStylesheet extends Node {
             css: string;
         }

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -51,6 +51,16 @@ type GRVSCCodeBlock implements Node {
   additionalThemes: [GRVSCTheme!]!
   tokenizedLines: [GRVSCTokenizedLine!]
 }
+type GRVSCCodeSpan implements Node {
+  index: Int!
+  html: String!
+  text: String!
+  className: String!
+  language: String
+  defaultTheme: GRVSCTheme!
+  additionalThemes: [GRVSCTheme!]!
+  tokens: [GRVSCToken!]!
+}
 type GRVSCStylesheet implements Node {
   css: String!
 }

--- a/src/parseCodeFenceInfo.js
+++ b/src/parseCodeFenceInfo.js
@@ -17,7 +17,7 @@ function test(input, pattern) {
  * @param {string} lang
  * @param {string=} metaString
  */
-function parseCodeFenceHeader(lang, metaString) {
+function parseCodeFenceInfo(lang, metaString) {
   let pos = 0;
   let meta = {};
   let languageName = '';
@@ -170,4 +170,4 @@ function parseCodeFenceHeader(lang, metaString) {
   }
 }
 
-module.exports = parseCodeFenceHeader;
+module.exports = parseCodeFenceInfo;

--- a/src/parseCodeSpanInfo.js
+++ b/src/parseCodeSpanInfo.js
@@ -1,0 +1,14 @@
+/**
+ * @param {string} text
+ * @param {string} delimiter
+ * @returns {{ languageName: string | undefined, meta: undefined, text: string }}
+ */
+function parseCodeSpanInfo(text, delimiter) {
+  const index = text.indexOf(delimiter);
+  if (index <= 0) return { languageName: undefined, meta: undefined, text };
+  const languageName = text.slice(0, index).trim().toLowerCase();
+  if (!languageName) return { languageName: undefined, meta: undefined, text };
+  return { languageName, meta: undefined, text: text.slice(index + delimiter.length) };
+}
+
+module.exports = parseCodeSpanInfo;

--- a/src/parseCodeSpanInfo.js
+++ b/src/parseCodeSpanInfo.js
@@ -6,7 +6,10 @@
 function parseCodeSpanInfo(text, delimiter) {
   const index = text.indexOf(delimiter);
   if (index <= 0) return { languageName: undefined, meta: undefined, text };
-  const languageName = text.slice(0, index).trim().toLowerCase();
+  const languageName = text
+    .slice(0, index)
+    .trim()
+    .toLowerCase();
   if (!languageName) return { languageName: undefined, meta: undefined, text };
   return { languageName, meta: undefined, text: text.slice(index + delimiter.length) };
 }

--- a/src/registerCodeNode.js
+++ b/src/registerCodeNode.js
@@ -3,7 +3,7 @@ const { getTransformedLines } = require('./transformers');
 const { getGrammar } = require('./storeUtils');
 
 /**
- * @template TKey
+ * @template {Keyable} TKey
  * @param {CodeNodeRegistry<TKey>} codeBlockRegistry
  * @param {TKey} registryKey
  * @param {ConditionalTheme[]} possibleThemes
@@ -58,7 +58,7 @@ async function registerCodeBlock(
 }
 
 /**
- * @template TKey
+ * @template {Keyable} TKey
  * @param {CodeNodeRegistry<TKey>} codeBlockRegistry
  * @param {TKey} registryKey
  * @param {ConditionalTheme[]} possibleThemes

--- a/src/themeUtils.js
+++ b/src/themeUtils.js
@@ -205,7 +205,7 @@ function getStylesFromThemeSettings(settings) {
 
 /**
  * @param {LegacyThemeOption} themeOption
- * @returns {ThemeOption}
+ * @returns {ThemeOption<CodeBlockData>}
  */
 function convertLegacyThemeOption(themeOption) {
   if (typeof themeOption === 'function') {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -143,7 +143,7 @@ interface ConditionalTheme {
 
 type RawTheme = import('vscode-textmate').IRawTheme & { resultColors: Record<string, string> };
 
-interface RegisteredCodeBlockData {
+interface RegisteredCodeNodeData {
   index: number;
   meta: object;
   text: string;
@@ -161,6 +161,10 @@ interface RegisteredToken {
   endIndex: number;
   defaultThemeTokenData: grvsc.gql.GRVSCThemeTokenData;
   additionalThemeTokenData: grvsc.gql.GRVSCThemeTokenData[];
+}
+
+interface Keyable {
+  type: 'code' | 'inlineCode';
 }
 
 interface MDASTNode<T = string> {
@@ -181,15 +185,16 @@ type Line = {
   data: object;
 };
 
-interface CodeNodeRegistry<TKey> {
-  register: (key: TKey, data: Omit<RegisteredCodeBlockData, 'index'>) => void;
+interface CodeNodeRegistry<TKey extends Keyable> {
+  register: (key: TKey, data: Omit<RegisteredCodeNodeData, 'index'>) => void;
   forEachLine: (codeBlockKey: TKey, action: (line: Line, index: number, lines: Line[]) => void) => void;
   forEachToken: (
     key: TKey,
     lineIndex: number,
     tokenAction: (token: RegisteredToken) => void
   ) => void;
-  forEachCodeBlock: (action: (data: RegisteredCodeBlockData & { index: number }, codeBlockKey: TKey) => void) => void;
+  forEachCodeBlock: (action: (data: RegisteredCodeNodeData, codeBlockKey: TKey & { type: 'code' }) => void) => void;
+  forEachCodeSpan: (action: (data: RegisteredCodeNodeData, codeSpanKey: TKey & { type: 'inlineCode' }) => void) => void;
   getAllPossibleThemes: () => { theme: ConditionalTheme, settings: Record<string, string> }[];
   getTokenStylesForTheme: (themeIdentifier: string) => { className: string, css: grvsc.CSSDeclaration[] }[];
 }

--- a/src/validateOptions.js
+++ b/src/validateOptions.js
@@ -1,6 +1,8 @@
 const { EOL } = require('os');
 const { deprecationNotice, isRelativePath } = require('./utils');
 
+const validMarkerRegExp = /^[^\sa-zA-Z0-9.-_`\\<]+$/;
+
 /**
  * @param {PluginOptions} options
  */
@@ -30,6 +32,14 @@ function validateOptions(options) {
         addError('extensions', `Extension paths must be absolute. Received '${extension}'.`);
       }
     });
+  }
+
+  if (options.inlineCode) {
+    if (!('marker' in options.inlineCode)) {
+      addError('inlineCode', `Key 'marker' is required.`);
+    } else if (typeof options.inlineCode.marker !== 'string' || !validMarkerRegExp.test(options.inlineCode.marker)) {
+      addError('inlineCode.marker', `Marker must be a string without whitespace, ASCII letters or numerals, or character: .-_\`\\<`);
+    }
   }
 
   if (errors.length) {

--- a/src/validateOptions.js
+++ b/src/validateOptions.js
@@ -38,7 +38,10 @@ function validateOptions(options) {
     if (!('marker' in options.inlineCode)) {
       addError('inlineCode', `Key 'marker' is required.`);
     } else if (typeof options.inlineCode.marker !== 'string' || !validMarkerRegExp.test(options.inlineCode.marker)) {
-      addError('inlineCode.marker', `Marker must be a string without whitespace, ASCII letters or numerals, or character: .-_\`\\<`);
+      addError(
+        'inlineCode.marker',
+        `Marker must be a string without whitespace, ASCII letters or numerals, or character: .-_\`\\<`
+      );
     }
   }
 

--- a/test/integration/baselines/inline-custom-class.html
+++ b/test/integration/baselines/inline-custom-class.html
@@ -1,0 +1,51 @@
+<h1>Inline Code</h1>
+<p>Lorem <code>ipsum</code>, and <code class="my-inline-code default-light" data-language="css" data-index="0"><span class="mtk11">.</span><span class="mtk11">grvsc-container</span><span class="mtk1"> </span><span class="mtk1">{</span><span class="mtk1"> </span><span class="mtk6">display</span><span class="mtk1">:</span><span class="mtk1"> </span><span class="mtk8">block</span><span class="mtk1"> </span><span class="mtk1">}</span></code>.</p>
+<p><code class="my-inline-code default-light" data-language="ts" data-index="1"><span class="mtk1">(</span><span class="mtk12">x</span><span class="mtk1">:</span><span class="mtk1"> </span><span class="mtk9">string</span><span class="mtk1">,</span><span class="mtk1"> </span><span class="mtk12">y</span><span class="mtk1">:</span><span class="mtk1"> </span><span class="mtk9">boolean</span><span class="mtk1">)</span><span class="mtk1"> </span><span class="mtk4">=></span><span class="mtk1"> </span><span class="mtk1">{</span><span class="mtk1">}</span></code></p>
+<p><code class="my-inline-code default-light" data-language="sh" data-index="2"><span class="mtk1"> leading space should be preserved</span></code></p>
+<p><code class="my-inline-code default-light" data-language="js" data-index="3"><span class="mtk17">`</span><span class="mtk17">This should be fine </span><span class="mtk4">${</span><span class="mtk12">because</span><span class="mtk4">}</span><span class="mtk17"> the Markdown parser should have already trimmed the leading space.</span><span class="mtk17">`</span></code></p>
+<style class="grvsc-styles">
+  .grvsc-container {
+    overflow: auto;
+    -webkit-overflow-scrolling: touch;
+    padding-top: 1rem;
+    padding-top: var(--grvsc-padding-top, var(--grvsc-padding-v, 1rem));
+    padding-bottom: 1rem;
+    padding-bottom: var(--grvsc-padding-bottom, var(--grvsc-padding-v, 1rem));
+    border-radius: 8px;
+    border-radius: var(--grvsc-border-radius, 8px);
+    font-feature-settings: normal;
+  }
+  
+  .grvsc-code {
+    display: inline-block;
+    min-width: 100%;
+  }
+  
+  .grvsc-line {
+    display: inline-block;
+    box-sizing: border-box;
+    width: 100%;
+    padding-left: 1.5rem;
+    padding-left: var(--grvsc-padding-left, var(--grvsc-padding-h, 1.5rem));
+    padding-right: 1.5rem;
+    padding-right: var(--grvsc-padding-right, var(--grvsc-padding-h, 1.5rem));
+  }
+  
+  .grvsc-line-highlighted {
+    background-color: var(--grvsc-line-highlighted-background-color, transparent);
+    box-shadow: inset var(--grvsc-line-highlighted-border-width, 4px) 0 0 0 var(--grvsc-line-highlighted-border-color, transparent);
+  }
+  
+  .default-light {
+    background-color: #FFFFFF;
+    color: #000000;
+  }
+  .default-light .mtk11 { color: #800000; }
+  .default-light .mtk1 { color: #000000; }
+  .default-light .mtk6 { color: #FF0000; }
+  .default-light .mtk8 { color: #0451A5; }
+  .default-light .mtk12 { color: #001080; }
+  .default-light .mtk9 { color: #267F99; }
+  .default-light .mtk4 { color: #0000FF; }
+  .default-light .mtk17 { color: #A31515; }
+</style>

--- a/test/integration/baselines/inline-theme-function.html
+++ b/test/integration/baselines/inline-theme-function.html
@@ -1,0 +1,64 @@
+<h1>Inline Code</h1>
+<p>Lorem <code>ipsum</code>, and <code class="my-inline-code abyss" data-language="css" data-index="0"><span class="mtk6">.</span><span class="mtk6">grvsc-container</span><span class="mtk1"> </span><span class="mtk1">{</span><span class="mtk1"> </span><span class="mtk15 mtki">display</span><span class="mtk1">:</span><span class="mtk1"> </span><span class="mtk15">block</span><span class="mtk1"> </span><span class="mtk1">}</span></code>.</p>
+<p><code class="my-inline-code abyss" data-language="ts" data-index="1"><span class="mtk1">(</span><span class="mtk19 mtki">x</span><span class="mtk7">:</span><span class="mtk1"> </span><span class="mtk15 mtki">string</span><span class="mtk1">,</span><span class="mtk1"> </span><span class="mtk19 mtki">y</span><span class="mtk7">:</span><span class="mtk1"> </span><span class="mtk15 mtki">boolean</span><span class="mtk1">)</span><span class="mtk1"> </span><span class="mtk15 mtki">=></span><span class="mtk1"> </span><span class="mtk1">{</span><span class="mtk1">}</span></code></p>
+<p><code class="my-inline-code abyss" data-language="sh" data-index="2"><span class="mtk1"> leading space should be preserved</span></code></p>
+<p><code class="my-inline-code default-light grvsc-mm-tYvMB2" data-language="js" data-index="3"><span class="grvsc-t7UkM5-17 grvsc-tYvMB2-8">`</span><span class="grvsc-t7UkM5-17 grvsc-tYvMB2-8">This should be fine </span><span class="grvsc-t7UkM5-4 grvsc-tYvMB2-4">${</span><span class="grvsc-t7UkM5-12 grvsc-tYvMB2-12">because</span><span class="grvsc-t7UkM5-4 grvsc-tYvMB2-4">}</span><span class="grvsc-t7UkM5-17 grvsc-tYvMB2-8"> the Markdown parser should have already trimmed the leading space.</span><span class="grvsc-t7UkM5-17 grvsc-tYvMB2-8">`</span></code></p>
+<style class="grvsc-styles">
+  .grvsc-container {
+    overflow: auto;
+    -webkit-overflow-scrolling: touch;
+    padding-top: 1rem;
+    padding-top: var(--grvsc-padding-top, var(--grvsc-padding-v, 1rem));
+    padding-bottom: 1rem;
+    padding-bottom: var(--grvsc-padding-bottom, var(--grvsc-padding-v, 1rem));
+    border-radius: 8px;
+    border-radius: var(--grvsc-border-radius, 8px);
+    font-feature-settings: normal;
+  }
+  
+  .grvsc-code {
+    display: inline-block;
+    min-width: 100%;
+  }
+  
+  .grvsc-line {
+    display: inline-block;
+    box-sizing: border-box;
+    width: 100%;
+    padding-left: 1.5rem;
+    padding-left: var(--grvsc-padding-left, var(--grvsc-padding-h, 1.5rem));
+    padding-right: 1.5rem;
+    padding-right: var(--grvsc-padding-right, var(--grvsc-padding-h, 1.5rem));
+  }
+  
+  .grvsc-line-highlighted {
+    background-color: var(--grvsc-line-highlighted-background-color, transparent);
+    box-shadow: inset var(--grvsc-line-highlighted-border-width, 4px) 0 0 0 var(--grvsc-line-highlighted-border-color, transparent);
+  }
+  
+  .abyss { background-color: #000c18; }
+  .abyss .mtki { font-style: italic; }
+  .abyss .mtk6 { color: #DDBB88; }
+  .abyss .mtk1 { color: #6688CC; }
+  .abyss .mtk15 { color: #9966B8; }
+  .abyss .mtk19 { color: #2277FF; }
+  .abyss .mtk7 { color: #225588; }
+  .default-light {
+    background-color: #FFFFFF;
+    color: #000000;
+  }
+  .default-light .grvsc-t7UkM5-17 { color: #A31515; }
+  .default-light .grvsc-t7UkM5-4 { color: #0000FF; }
+  .default-light .grvsc-t7UkM5-12 { color: #001080; }
+  
+  /* Default Dark+ */
+  @media (prefers-color-scheme: dark) {
+    .grvsc-mm-tYvMB2 {
+      background-color: #1E1E1E;
+      color: #D4D4D4;
+    }
+    .grvsc-mm-tYvMB2 .grvsc-tYvMB2-8 { color: #CE9178; }
+    .grvsc-mm-tYvMB2 .grvsc-tYvMB2-4 { color: #569CD6; }
+    .grvsc-mm-tYvMB2 .grvsc-tYvMB2-12 { color: #9CDCFE; }
+  }
+</style>

--- a/test/integration/baselines/inline.html
+++ b/test/integration/baselines/inline.html
@@ -1,0 +1,51 @@
+<h1>Inline Code</h1>
+<p>Lorem <code>ipsum</code>, and <code class="default-light" data-language="css" data-index="0"><span class="mtk11">.</span><span class="mtk11">grvsc-container</span><span class="mtk1"> </span><span class="mtk1">{</span><span class="mtk1"> </span><span class="mtk6">display</span><span class="mtk1">:</span><span class="mtk1"> </span><span class="mtk8">block</span><span class="mtk1"> </span><span class="mtk1">}</span></code>.</p>
+<p><code class="default-light" data-language="ts" data-index="1"><span class="mtk1">(</span><span class="mtk12">x</span><span class="mtk1">:</span><span class="mtk1"> </span><span class="mtk9">string</span><span class="mtk1">,</span><span class="mtk1"> </span><span class="mtk12">y</span><span class="mtk1">:</span><span class="mtk1"> </span><span class="mtk9">boolean</span><span class="mtk1">)</span><span class="mtk1"> </span><span class="mtk4">=></span><span class="mtk1"> </span><span class="mtk1">{</span><span class="mtk1">}</span></code></p>
+<p><code class="default-light" data-language="sh" data-index="2"><span class="mtk1"> leading space should be preserved</span></code></p>
+<p><code class="default-light" data-language="js" data-index="3"><span class="mtk17">`</span><span class="mtk17">This should be fine </span><span class="mtk4">${</span><span class="mtk12">because</span><span class="mtk4">}</span><span class="mtk17"> the Markdown parser should have already trimmed the leading space.</span><span class="mtk17">`</span></code></p>
+<style class="grvsc-styles">
+  .grvsc-container {
+    overflow: auto;
+    -webkit-overflow-scrolling: touch;
+    padding-top: 1rem;
+    padding-top: var(--grvsc-padding-top, var(--grvsc-padding-v, 1rem));
+    padding-bottom: 1rem;
+    padding-bottom: var(--grvsc-padding-bottom, var(--grvsc-padding-v, 1rem));
+    border-radius: 8px;
+    border-radius: var(--grvsc-border-radius, 8px);
+    font-feature-settings: normal;
+  }
+  
+  .grvsc-code {
+    display: inline-block;
+    min-width: 100%;
+  }
+  
+  .grvsc-line {
+    display: inline-block;
+    box-sizing: border-box;
+    width: 100%;
+    padding-left: 1.5rem;
+    padding-left: var(--grvsc-padding-left, var(--grvsc-padding-h, 1.5rem));
+    padding-right: 1.5rem;
+    padding-right: var(--grvsc-padding-right, var(--grvsc-padding-h, 1.5rem));
+  }
+  
+  .grvsc-line-highlighted {
+    background-color: var(--grvsc-line-highlighted-background-color, transparent);
+    box-shadow: inset var(--grvsc-line-highlighted-border-width, 4px) 0 0 0 var(--grvsc-line-highlighted-border-color, transparent);
+  }
+  
+  .default-light {
+    background-color: #FFFFFF;
+    color: #000000;
+  }
+  .default-light .mtk11 { color: #800000; }
+  .default-light .mtk1 { color: #000000; }
+  .default-light .mtk6 { color: #FF0000; }
+  .default-light .mtk8 { color: #0451A5; }
+  .default-light .mtk12 { color: #001080; }
+  .default-light .mtk9 { color: #267F99; }
+  .default-light .mtk4 { color: #0000FF; }
+  .default-light .mtk17 { color: #A31515; }
+</style>

--- a/test/integration/cases/inline-custom-class/options.js
+++ b/test/integration/cases/inline-custom-class/options.js
@@ -1,0 +1,7 @@
+module.exports = {
+  inlineCode: {
+    theme: 'Default Light+',
+    marker: '•',
+    className: 'my-inline-code'
+  }
+};

--- a/test/integration/cases/inline-custom-class/test.md
+++ b/test/integration/cases/inline-custom-class/test.md
@@ -1,0 +1,9 @@
+# Inline Code
+
+Lorem `ipsum`, and `css•.grvsc-container { display: block }`.
+
+``ts•(x: string, y: boolean) => {}``
+
+`sh• leading space should be preserved`
+
+`` js•`This should be fine ${because} the Markdown parser should have already trimmed the leading space.` ``

--- a/test/integration/cases/inline-theme-function/options.js
+++ b/test/integration/cases/inline-theme-function/options.js
@@ -1,0 +1,15 @@
+module.exports = {
+  inlineCode: {
+    theme: ({ language }) => {
+      if (language === 'js') {
+        return {
+          default: 'Default Light+',
+          dark: 'Default Dark+'
+        };
+      }
+      return 'Abyss';
+    },
+    marker: '•',
+    className: 'my-inline-code'
+  }
+};

--- a/test/integration/cases/inline-theme-function/test.md
+++ b/test/integration/cases/inline-theme-function/test.md
@@ -1,0 +1,9 @@
+# Inline Code
+
+Lorem `ipsum`, and `css•.grvsc-container { display: block }`.
+
+``ts•(x: string, y: boolean) => {}``
+
+`sh• leading space should be preserved`
+
+`` js•`This should be fine ${because} the Markdown parser should have already trimmed the leading space.` ``

--- a/test/integration/cases/inline/options.js
+++ b/test/integration/cases/inline/options.js
@@ -1,0 +1,6 @@
+module.exports = {
+  inlineCode: {
+    theme: 'Default Light+',
+    marker: '•'
+  }
+};

--- a/test/integration/cases/inline/test.md
+++ b/test/integration/cases/inline/test.md
@@ -1,0 +1,9 @@
+# Inline Code
+
+Lorem `ipsum`, and `css•.grvsc-container { display: block }`.
+
+``ts•(x: string, y: boolean) => {}``
+
+`sh• leading space should be preserved`
+
+`` js•`This should be fine ${because} the Markdown parser should have already trimmed the leading space.` ``

--- a/test/parseCodeFenceHeader.test.js
+++ b/test/parseCodeFenceHeader.test.js
@@ -1,7 +1,7 @@
 // @ts-check
-const parse = require('../src/parseCodeFenceHeader');
+const parse = require('../src/parseCodeFenceInfo');
 
-describe('parseCodeFenceHeader', () => {
+describe('parseCodeFenceInfo', () => {
   it('parses language name without meta', () => {
     expect(parse('jsx')).toEqual({ languageName: 'jsx', meta: {} });
     expect(parse('c++')).toEqual({ languageName: 'c++', meta: {} });


### PR DESCRIPTION
Closes #76 

Copying implementation instructions from issue:

- [x] Make the changes to `types.d.ts` I mentioned above.
- [x] Introduce a new type into `schema.graphql` to represent inline code. It should look just like [`GRVSCCodeBlock`](https://github.com/andrewbranch/gatsby-remark-vscode/blob/cf3d33dfc294976b9254c8780dee0c5146dc299b/src/graphql/schema.graphql#L42), bet can replace `preClassName` and `codeClassName` with just `className`, omit `meta`, and replace `tokenizedLines` with `tokens: [GRVSCToken!]!`. (Run `npm run build` after this to update `schema.d.ts`.)
- [x] Add validation for “if `options.inlineCode` exists, `options.inlineCode.marker` must exist in `validateOptions.js`.
- [x] Update the [AST visitor](https://github.com/andrewbranch/gatsby-remark-vscode/blob/cf3d33dfc294976b9254c8780dee0c5146dc299b/src/index.js#L63-L65) to look for both `code` and `inlineCode` nodes, if `options.inlineCode` is defined. (I think you can replace the string `'code'` test with a callback function that accepts a node, where you can check its `type`. [API](https://github.com/syntax-tree/unist-util-visit-parents))
- [x] In the initial [loop over code nodes](https://github.com/andrewbranch/gatsby-remark-vscode/blob/cf3d33dfc294976b9254c8780dee0c5146dc299b/src/index.js#L75), you’ll need to branch on `node.type` for some things. E.g., instead of [calling `parseCodeFenceHeader`](https://github.com/andrewbranch/gatsby-remark-vscode/blob/cf3d33dfc294976b9254c8780dee0c5146dc299b/src/index.js#L79), you’ll need to call a new similar parsing function that separates the node text into `language` and `text`. If you don’t detect a language (i.e., you never see `inlineCode.marker`), I think you can just `continue` and be done with that node. The call to [`getPossibleThemes`](https://github.com/andrewbranch/gatsby-remark-vscode/blob/cf3d33dfc294976b9254c8780dee0c5146dc299b/src/index.js#L91) needs to use `inlineCode.theme || theme` if `node.type === 'inlineCode'`. Otherwise, I think most of that loop body stays the same. In the [`registerCodeBlock` function](https://github.com/andrewbranch/gatsby-remark-vscode/blob/cf3d33dfc294976b9254c8780dee0c5146dc299b/src/index.js#L101), I think we should probably not [run line transformers](https://github.com/andrewbranch/gatsby-remark-vscode/blob/cf3d33dfc294976b9254c8780dee0c5146dc299b/src/registerCodeBlock.js#L33) on inline code nodes.
- [x] The next loop, [`registry.forEachCodeBlock`](https://github.com/andrewbranch/gatsby-remark-vscode/blob/cf3d33dfc294976b9254c8780dee0c5146dc299b/src/index.js#L120), goes back over the nodes and generates HTML for them. The actual HTML generation is in [`getCodeBlockDataFromRegistry`](https://github.com/andrewbranch/gatsby-remark-vscode/blob/cf3d33dfc294976b9254c8780dee0c5146dc299b/src/graphql/getCodeBlockDataFromRegistry.js#L30). Probably about half the stuff in here is actually specific to code _blocks_, and I think it might be too messy to make it polymorphic, so I would probably recommend making `registry.forEachInlineCode` and `getInlineCodeDataFromRegistry` functions instead, and repeating/extracting the relevant things from what’s there now. While generating HTML is the bulk of the work in this function, its full purpose is to generate a JavaScript object [matching](https://github.com/andrewbranch/gatsby-remark-vscode/blob/cf3d33dfc294976b9254c8780dee0c5146dc299b/src/graphql/getCodeBlockDataFromRegistry.js#L14) the new type you added to the GraphQL schema in step 2.
- [x] Back in `index.js` in your `[codeBlockRegistry.forEachInlineCode]` loop, you can [finish generating the GraphQL node](https://github.com/andrewbranch/gatsby-remark-vscode/blob/cf3d33dfc294976b9254c8780dee0c5146dc299b/src/index.js#L133-L144) in the same way as `registry.forEachCodeBlock` and push it onto the same `graphQLNodes` array.
- [x] Write some [integration tests](https://github.com/andrewbranch/gatsby-remark-vscode/blob/master/CONTRIBUTING.md#tests). Try to cover the API surface.

And a step I forgot:

- [x] Add a new GraphQL resolver for `GRVSCCodeSpan` in `gatsby-config.js`