### PR TITLE
Add gutterCell to graphql schema

### DIFF
--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -17,8 +17,13 @@ type GRVSCToken {
   defaultThemeTokenData: GRVSCThemeTokenData!
   additionalThemeTokenData: [GRVSCThemeTokenData!]!
 }
+type GRVSCGutterCell {
+  className: String!
+  text: String!
+}
 type GRVSCTokenizedLine {
   tokens: [GRVSCToken!]!
+  gutterCells: [GRVSCGutterCell]
   text: String!
   html: String!
   attrs: JSON!


### PR DESCRIPTION
When making queries to the GRVSC graphql nodes, an error is thrown if you try querying for gutterCells if they haven't been inferred.