### PR TITLE
Allow additional code fence meta

### DIFF
--- a/src/parseCodeFenceInfo.js
+++ b/src/parseCodeFenceInfo.js
@@ -21,7 +21,7 @@ function parseCodeFenceInfo(lang, metaString) {
   let pos = 0;
   let meta = {};
   let languageName = '';
-  const input = lang + (metaString || '');
+  const input = [lang, metaString].filter(Boolean).join(' ');
   skipTrivia();
   if (!isEnd() && current() !== '{') {
     languageName = parseIdentifier();
@@ -32,11 +32,8 @@ function parseCodeFenceInfo(lang, metaString) {
     meta = parseObject();
   }
 
-  if (!isEnd()) {
-    if (languageNameEnd === pos) {
-      return fail(`Invalid character in language name: '${current()}'`);
-    }
-    return fail(`Unrecognized input: '${current()}'`);
+  if (!isEnd() && languageNameEnd === pos) {
+    return fail(`Invalid character in language name: '${current()}'`);
   }
 
   return { languageName, meta };

--- a/test/unit/parseCodeFenceHeader.test.js
+++ b/test/unit/parseCodeFenceHeader.test.js
@@ -54,6 +54,10 @@ describe('parseCodeFenceInfo', () => {
     expect(() => parse('jsx{ : }')).toThrowError(/expected identifier/i);
     expect(() => parse('jsx{ a: "')).toThrowError(/unexpected end of input/i);
     expect(() => parse('c%')).toThrowError(/invalid character in language name.+?%/i);
-    expect(() => parse('c %')).toThrowError(/unrecognized input.+?%/i);
+  });
+
+  it('ignores additional meta', () => {
+    expect(parse('jsx codesandbox=react')).toEqual({ languageName: 'jsx', meta: {} });
+    expect(parse('js file=some/dir/file.js')).toEqual({ languageName: 'js', meta: {} });
   });
 });


### PR DESCRIPTION
Allow and ignore additional code fence meta strings. So that this plugin can be used with [`remark-codesandbox`](https://github.com/kevin940726/remark-codesandbox), [`remark-code-import`](https://github.com/kevin940726/remark-code-import), or [`gatsby-remark-import-code`](https://github.com/pomber/gatsby-remark-import-code).

This PR should be backward-compatible. It just loosens the check a little bit to allow it to integrate with other (gatsby-)remark plugins.

Please let me know what you think of this :)