### PR TITLE
The theme must be defined as an object

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ Add to your `gatsby-config.js`:
       plugins: [{
         resolve: `gatsby-remark-vscode`,
         options: {
-          theme: 'Abyss' // Or install your favorite theme from GitHub
+          theme: {
+            default: 'Abyss' // Or install your favorite theme from GitHub
+          },
         }
       }]
     }


### PR DESCRIPTION
Hello there,

When I tried to install the plugin yesterday, I was unable to use the theme I defined. I could not use it as in the document, so the theme should be defined as an object.