### PR TITLE
Fix diff highlighting getting cut off

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -20,7 +20,6 @@
   display: table-row;
   box-sizing: border-box;
   width: 100%;
-  position: relative;
 }
 
 .grvsc-line > * {


### PR DESCRIPTION
With `position: relative`

![image](https://user-images.githubusercontent.com/68407783/163691328-d8063600-826b-47fc-b745-73a0c09e0b5f.png)

Without `position: relative`

![image](https://user-images.githubusercontent.com/68407783/163691337-8016e52b-b664-493f-a46a-1360fe11df84.png)

I'm not sure why position: relative overrides the width: 100%, but removing position: relative didn't seem to break anything else.