### PR TITLE
Fix Usage as a remark plugin without Gatsby example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,27 +557,37 @@ Line numbers and ranges aren’t the only things you can pass as options on your
 
 ### Usage as a remark plugin without Gatsby
 
-This package exports a `remarkPlugin` property that accepts the same [options](#options-reference) as the main Gatsby plugin and is usable as a [remark](https://github.com/remarkjs/remark) plugin in any [unifiedjs](https://github.com/unifiedjs/unified) processing pipeline:
+This package exports a `remarkPlugin` property that accepts the same [options](#options-reference) as the main Gatsby plugin and is usable as a [remark](https://github.com/remarkjs/remark) plugin in any [unifiedjs](https://github.com/unifiedjs/unified) processing pipeline.
+
+First, install the required dependencies:
+
+```shell
+npm install unified remark-parse gatsby-remark-vscode remark-rehype rehype-raw rehype-stringify
+```
+
+Then, in an ES Module file, e.g., index.mjs:
 
 ````js
-const unified = require('unified');
-const remarkParse = require('remarkParse');
-const remarkVscode = require('gatsby-remark-vscode');
-const remarkToRehype = require('remark-rehype');
-const rehypeRaw = require('rehype-raw');
-const rehypeStringify = require('rehype-stringify');
+import { unified } from 'unified'
+import remarkParse from 'remark-parse'
+import remarkVscode from 'gatsby-remark-vscode'
+import remarkToRehype from 'remark-rehype'
+import rehypeRaw from 'rehype-raw'
+import rehypeStringify from 'rehype-stringify'
 
 const markdownSource = `
 # Code example with awesome syntax highlighting
 
-```ts {numberLines}
+\`\`\`ts {numberLines}
 export function sum(a: number, b: number): number {
   return a + b;
 }
-```
+\`\`\`
 
 This is a paragraph after the code example.
 `
+
+console.log(markdownSource)
 
 const processor = unified()
   // parse markdown to remark AST
@@ -597,7 +607,7 @@ const processor = unified()
   });
 
 const vfile = await processor.process(markdownSource);
-console.log(vfile.contents); // logs resulting HTML
+console.log(vfile.value); // logs resulting HTML
 ````
 
 ## Options reference

--- a/README.md
+++ b/README.md
@@ -587,8 +587,6 @@ export function sum(a: number, b: number): number {
 This is a paragraph after the code example.
 `
 
-console.log(markdownSource)
-
 const processor = unified()
   // parse markdown to remark AST
   .use(remarkParse)


### PR DESCRIPTION
The example in the Usage as a remark plugin without Gatsby section does not compile as is:

- Top-level await only available in ES Modules but used here with require() – decided to go with the former and use imports
- Backticks not escaped in template string
- Incorrect module name (`remarkParse` should be `remark-parse`)
- Incorrect property reference in result returned from processor (`contents` should be `value`) 

I also added the npm install line required and a suggestion of the file name to use (including _.mjs_ extension) to make it easier to follow and avoid possible trip-ups.